### PR TITLE
api/nomad: Add Nomad Scaling Support

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -4,10 +4,35 @@ import (
 	"regexp"
 )
 
-func findIP(input string) string {
+// FindIP will return the IP address from a string. This is used to deal with
+// responses from the Nomad API that contain the port such as 127.0.0.1:4646.
+func FindIP(input string) string {
 	numBlock := "(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])"
 	regexPattern := numBlock + "\\." + numBlock + "\\." + numBlock + "\\." + numBlock
 
 	regEx := regexp.MustCompile(regexPattern)
 	return regEx.FindString(input)
+}
+
+// Max returns the largest float from a variable length list of floats.
+func Max(values ...float64) float64 {
+	max := values[0]
+	for _, i := range values[1:] {
+		if i > max {
+			max = i
+		}
+	}
+
+	return max
+}
+
+// Min returns the smallest float from a variable length list of floats.
+func Min(values ...float64) float64 {
+	min := values[0]
+	for _, i := range values[1:] {
+		if i < min {
+			min = i
+		}
+	}
+	return min
 }

--- a/api/nomad.go
+++ b/api/nomad.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/dariubs/percent"
+	"github.com/elsevier-core-engineering/replicator/helper"
 	nomad "github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -235,7 +236,7 @@ func (c *nomadClient) LeaderCheck() bool {
 		fmt.Printf("replicator: unable to retrieve local agent information")
 	} else {
 
-		if FindIP(leader) == self.Member.Addr {
+		if helper.FindIP(leader) == self.Member.Addr {
 			haveLeadership = true
 		}
 	}
@@ -284,7 +285,7 @@ func (c *nomadClient) TaskAllocationTotals(capacityUsed *ClusterAllocation) erro
 func (c *nomadClient) MostUtilizedResource(alloc *ClusterAllocation) {
 	// Determine the resource that is consuming the greatest percentage of its overall cluster
 	// capacity.
-	max := (Max(alloc.UsedCapacity.CPUPercent, alloc.UsedCapacity.MemoryPercent,
+	max := (helper.Max(alloc.UsedCapacity.CPUPercent, alloc.UsedCapacity.MemoryPercent,
 		alloc.UsedCapacity.DiskPercent))
 
 	// Set the compute cluster scaling metric to the most-utilized resource.

--- a/api/nomad.go
+++ b/api/nomad.go
@@ -2,68 +2,115 @@ package api
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/dariubs/percent"
 	nomad "github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/nomad/structs"
 )
 
-// The NomadClient interface is used to provide common method signatures for
-// interacting with the Nomad API.
+// NomadClient exposes all API methods needed to interact with the Nomad API,
+// evaluate cluster capacity and allocations and make scaling decisions.
 type NomadClient interface {
+	// ClusterAllocationCapacity determines the total cluster capacity and current
+	// number of worker nodes.
 	ClusterAllocationCapacity(*ClusterAllocation) error
+
+	// ClusterAssignedAllocation determines the consumed capacity across the
+	// cluster and tracks the resource consumption of each worker node.
 	ClusterAssignedAllocation(*ClusterAllocation) error
-	TaskAllocationTotals(*ClusterAllocation) error
+
+	// DrainNode places a worker node in drain mode to stop future allocations and
+	// migrate existing allocations to other worker nodes.
+	DrainNode(string) error
+
+	// LeaderCheck determines if the node running replicator is the gossip pool
+	// leader.
 	LeaderCheck() bool
+
+	// LeaseAllocatedNode determines the worker node consuming the least amount of
+	// the cluster's mosted-utilized resource.
+	LeastAllocatedNode(*ClusterAllocation) string
+
+	// MostUtilizedResource calculates which resource is most-utilized across the
+	// cluster. The worst-case allocation resource is prioritized when making
+	// scaling decisions.
+	MostUtilizedResource(*ClusterAllocation)
+
+	// TaskAllocationTotals calculates the allocations required by each running
+	// job and what amount of resources required if we increased the count of
+	// each job by one. This allows the cluster to proactively ensure it has
+	// sufficient capacity for scaling events and deal with potential node failures.
+	TaskAllocationTotals(*ClusterAllocation) error
 }
 
-// The nomadClient object is a wrapper to the Nomad client provided by the
-// Nomad API library.
+// Scaling metric types indicate the most-utilized resource across the cluster. When evaluating
+// scaling decisions, the most-utilized resource will be prioritized.
+const (
+	ScalingMetricNone      = "None" // All supported allocation resources are unutilized.
+	ScalingMetricDisk      = "Disk"
+	ScalingMetricMemory    = "Memory"
+	ScalingMetricProcessor = "CPU"
+)
+
+// ClusterAllocation is the central object used to track cluster status and the data
+// required to make scaling decisions.
+type ClusterAllocation struct {
+	// NodeCount is the number of worker nodes in a ready and non-draining state across
+	// the cluster.
+	NodeCount int
+
+	// ScalingMetric indicates the most-utilized allocation resource across the cluster.
+	// The most-utilized resource is prioritized when making scaling decisions like
+	// identifying the least-allocated worker node.
+	ScalingMetric string
+
+	// ClusterTotalAllocationCapacity is the total allocation capacity across the cluster.
+	TotalCapacity AllocationResources
+
+	// ClusterUsedAllocationCapacity is the consumed allocation capacity across the cluster.
+	UsedCapacity AllocationResources
+
+	// TaskAllocation represents the total allocation requirements of a single instance
+	// (count 1) of all running jobs across the cluster. This is used to practively
+	// ensure the cluster has sufficient available capacity to scale each task by +1
+	// if an increase in capacity is required.
+	TaskAllocation AllocationResources
+
+	// NodeList is a list of all worker nodes in a known good state.
+	NodeList []string
+
+	// NodeAllocations is a slice of node allocations.
+	NodeAllocations []*NodeAllocation
+}
+
+// NodeAllocation describes the resource consumption of a specific worker node.
+type NodeAllocation struct {
+	// NodeID is the unique ID of the worker node.
+	NodeID string
+
+	// UsedCapacity represents the percentage of total cluster resources consumed by
+	// the worker node.
+	UsedCapacity AllocationResources
+}
+
+// AllocationResources represents the allocation resource utilization.
+type AllocationResources struct {
+	MemoryMB      int
+	CPUMHz        int
+	DiskMB        int
+	MemoryPercent float64
+	CPUPercent    float64
+	DiskPercent   float64
+}
+
+// Provides a wrapper to the Nomad API package.
 type nomadClient struct {
 	nomad *nomad.Client
 }
 
-// ClusterAllocation is the main struct used for compiling information regarding
-// the cluster state which allows us to make cluster scaling decisions.
-type ClusterAllocation struct {
-	// NodeCount is the count of worker nodes in a ready and non-draining state in
-	// the cluster.
-	NodeCount int
-
-	// ClusterTotalAllocationCapacity is the total allocation which the cluster
-	// can support.
-	ClusterTotalAllocationCapacity totalAllocationCapacity
-
-	// ClusterUsedAllocationCapacity is the currently used cluster allocation
-	// across the cluster.
-	ClusterUsedAllocationCapacity usedAllocationCapacity
-
-	// TaskAllocation is the allocation total of all running jobs on the cluster
-	// assuming the count = 1. This is used in order to ensure the cluster has
-	// enough free capacity to scale each task by 1 if an increase in capacity is
-	// required.
-	TaskAllocation taskAllocation
-}
-
-type totalAllocationCapacity struct {
-	MemoryMB int
-	CPUMHz   int
-	DiskMB   int
-}
-
-type usedAllocationCapacity struct {
-	MemoryMB int
-	CPUMHz   int
-	DiskMB   int
-}
-
-type taskAllocation struct {
-	MemoryMB int
-	CPUMHz   int
-	DiskMB   int
-}
-
-// NewNomadClient is used to construct a new Nomad client using the default
-// configuration and supporting the ability to specify a Nomad API address
-// endpoint in the form of address:port.
+// NewNomadClient is used to create a new client to interact with Nomad. The
+// client implements the NomadClient interface.
 func NewNomadClient(addr string) (NomadClient, error) {
 	config := nomad.DefaultConfig()
 	config.Address = addr
@@ -75,21 +122,18 @@ func NewNomadClient(addr string) (NomadClient, error) {
 	return &nomadClient{nomad: c}, nil
 }
 
-// ClusterAllocationCapacity determines the total cluster allocation capacity as
-// well as the total number of available worker nodes.
+// ClusterAllocationCapacity calculates the total cluster capacity and determines the
+// number of available worker nodes.
 func (c *nomadClient) ClusterAllocationCapacity(capacity *ClusterAllocation) (err error) {
-
-	// Get a list of all nodes within the Nomad cluster so that the NodeID can
-	// then be interated upon to find node specific resources.
+	// Retrieve a list of all worker nodes within the cluster.
 	nodes, _, err := c.nomad.Nodes().List(&nomad.QueryOptions{})
 	if err != nil {
 		return err
 	}
 
-	// Iterate the NodeID's and call the Nodes.Info endpoint to gather detailed
-	// information about the node's resources. If the node is not listed as ready
-	// or the node is draining the node is ignored from calculations as we care
-	// about the current   available capacity.
+	// Get detailed information about each worker node, if the node is in a known-good
+	// state, increment the node count, add the node to the node list and add its
+	// resources to the overall cluster capacity.
 	for _, node := range nodes {
 		resp, _, err := c.nomad.Nodes().Info(node.ID, &nomad.QueryOptions{})
 		if err != nil {
@@ -98,44 +142,86 @@ func (c *nomadClient) ClusterAllocationCapacity(capacity *ClusterAllocation) (er
 
 		if (resp.Status == "ready") || (resp.Drain != true) {
 			capacity.NodeCount++
-			capacity.ClusterTotalAllocationCapacity.CPUMHz += *resp.Resources.CPU
-			capacity.ClusterTotalAllocationCapacity.MemoryMB += *resp.Resources.MemoryMB
-			capacity.ClusterTotalAllocationCapacity.DiskMB += *resp.Resources.DiskMB
+			capacity.NodeList = append(capacity.NodeList, node.ID)
+			capacity.TotalCapacity.CPUMHz += *resp.Resources.CPU
+			capacity.TotalCapacity.MemoryMB += *resp.Resources.MemoryMB
+			capacity.TotalCapacity.DiskMB += *resp.Resources.DiskMB
 		}
 	}
 
 	return nil
 }
 
-// ClusterAssignedAllocation iterates the current cluster allocations to provide
-// resource totals of what is currently running.
-func (c *nomadClient) ClusterAssignedAllocation(capacityUsed *ClusterAllocation) (err error) {
-
-	// Get a list of all allocations within the Nomad cluster so that the ID can
-	// then be interated upon to find allocation specific resources.
-	allocs, _, err := c.nomad.Allocations().List(&nomad.QueryOptions{})
-	if err != nil {
-		return err
-	}
-
-	// Iterate through the allocations list so that we can then call
-	// Allocations.Info on each to find what resources are assigned to it.
-	for _, alloc := range allocs {
-		resp, _, err := c.nomad.Allocations().Info(alloc.ID, &nomad.QueryOptions{})
+// ClusterAssignedAllocation calculates the total consumed resources across the cluster
+// and the amount of resources consumed by each worker node.
+func (c *nomadClient) ClusterAssignedAllocation(clusterInfo *ClusterAllocation) (err error) {
+	for _, node := range clusterInfo.NodeList {
+		allocations, _, err := c.nomad.Nodes().Allocations(node, &nomad.QueryOptions{})
 		if err != nil {
 			return err
 		}
 
-		if (resp.ClientStatus == "running") && (resp.DesiredStatus == "run") {
-			capacityUsed.ClusterUsedAllocationCapacity.CPUMHz += *resp.Resources.CPU
-			capacityUsed.ClusterUsedAllocationCapacity.MemoryMB += *resp.Resources.MemoryMB
-			capacityUsed.ClusterUsedAllocationCapacity.DiskMB += *resp.Resources.DiskMB
+		// Instantiate a new object to track the resource consumption of the worker node.
+		nodeInfo := &NodeAllocation{
+			NodeID:       node,
+			UsedCapacity: AllocationResources{},
 		}
+
+		for _, nodeAlloc := range allocations {
+			if (nodeAlloc.ClientStatus == "running") && (nodeAlloc.DesiredStatus == "run") {
+				// Add the consumed resources to the overall cluster consumed resource values.
+				clusterInfo.UsedCapacity.CPUMHz += *nodeAlloc.Resources.CPU
+				clusterInfo.UsedCapacity.MemoryMB += *nodeAlloc.Resources.MemoryMB
+				clusterInfo.UsedCapacity.DiskMB += *nodeAlloc.Resources.DiskMB
+
+				// Add the consumed resources to the node specific allocation object.
+				nodeInfo.UsedCapacity.CPUMHz += *nodeAlloc.Resources.CPU
+				nodeInfo.UsedCapacity.MemoryMB += *nodeAlloc.Resources.MemoryMB
+				nodeInfo.UsedCapacity.DiskMB += *nodeAlloc.Resources.DiskMB
+			}
+		}
+
+		// Add the node allocation record to the cluster status object.
+		clusterInfo.NodeAllocations = append(clusterInfo.NodeAllocations, nodeInfo)
 	}
-	return nil
+
+	// Determine the percentage of overall cluster resources consumed and calculate
+	// the amount of those resources consumed by the node.
+	CalculateUsage(clusterInfo)
+
+	return
 }
 
-// LeaderCheck determines if the local node has cluster leadership.
+// CalculateUsage determines the percentage of overall cluster resources consumed and
+// calculates the amount of those resources consumed by each worker node.
+func CalculateUsage(clusterInfo *ClusterAllocation) {
+	// For each allocation resource, calculate the percentage of overall cluster capacity
+	// consumed.
+	clusterInfo.UsedCapacity.CPUPercent = percent.PercentOf(
+		clusterInfo.UsedCapacity.CPUMHz,
+		clusterInfo.TotalCapacity.CPUMHz)
+
+	clusterInfo.UsedCapacity.DiskPercent = percent.PercentOf(
+		clusterInfo.UsedCapacity.DiskMB,
+		clusterInfo.TotalCapacity.DiskMB)
+
+	clusterInfo.UsedCapacity.MemoryPercent = percent.PercentOf(
+		clusterInfo.UsedCapacity.MemoryMB,
+		clusterInfo.TotalCapacity.MemoryMB)
+
+	// Determine the amount of consumed resources consumed by each worker node.
+	for _, nodeUsage := range clusterInfo.NodeAllocations {
+		nodeUsage.UsedCapacity.CPUPercent = percent.PercentOf(nodeUsage.UsedCapacity.CPUMHz,
+			clusterInfo.UsedCapacity.CPUMHz)
+		fmt.Printf("Node Used: %v (%v), Cluster Used: %v\n", nodeUsage.UsedCapacity.CPUMHz, nodeUsage.UsedCapacity.CPUPercent, clusterInfo.UsedCapacity.CPUMHz)
+		nodeUsage.UsedCapacity.DiskPercent = percent.PercentOf(nodeUsage.UsedCapacity.DiskMB,
+			clusterInfo.UsedCapacity.DiskMB)
+		nodeUsage.UsedCapacity.MemoryPercent = percent.PercentOf(nodeUsage.UsedCapacity.MemoryMB,
+			clusterInfo.UsedCapacity.MemoryMB)
+	}
+}
+
+// LeaderCheck determines if the node running the daemon is the gossip pool leader.
 func (c *nomadClient) LeaderCheck() bool {
 	haveLeadership := false
 
@@ -148,9 +234,8 @@ func (c *nomadClient) LeaderCheck() bool {
 	if err != nil {
 		fmt.Printf("replicator: unable to retrieve local agent information")
 	} else {
-		attributes := self["member"]
 
-		if findIP(leader) == attributes["Addr"].(string) {
+		if FindIP(leader) == self.Member.Addr {
 			haveLeadership = true
 		}
 	}
@@ -158,30 +243,26 @@ func (c *nomadClient) LeaderCheck() bool {
 	return haveLeadership
 }
 
-// TaskAllocationTotals iterates through the running jobs on the cluster to
-// determine the allocations required to scale each job task by a count of 1.
-// This is used to ensure the cluster have enough capacity for scaling events
-// as well as node failure events.
+// TaskAllocation determines the total allocation requirements of a single instance (count=1)
+// of all running jobs across the cluster. This is used to practively ensure the cluster
+// has sufficient available capacity to scale each task by +1 if an increase in capacity
+// is required.
 func (c *nomadClient) TaskAllocationTotals(capacityUsed *ClusterAllocation) error {
-
-	// Get a list of all the jobs on the cluster currently so that we can iterate
-	// the job.ID to find the total task resources assigned per job.
+	// Get all jobs across the cluster.
 	jobs, _, err := c.nomad.Jobs().List(&nomad.QueryOptions{})
 	if err != nil {
 		return err
 	}
 
-	// Iterate through the jobs list using the job.ID to call more detailed info
-	// about the job in order to discover
+	// Get detailed information about each job.
 	for _, job := range jobs {
 		resp, _, err := c.nomad.Jobs().Info(job.ID, &nomad.QueryOptions{})
 		if err != nil {
 			return err
 		}
 
-		// A job can contain multiple taskgroups which can intern contain multiple
-		// tasks; therefore we must iterate this fully. Nomad will only return jobs
-		// that are running, so we do not need to check the status.
+		// A job can contain multiple task groups which can themselves contain multiple tasks;
+		// therefore we must iterate fully. The API only returns jobs in a running state.
 		for _, taskG := range resp.TaskGroups {
 			for _, task := range taskG.Tasks {
 				capacityUsed.TaskAllocation.CPUMHz += *task.Resources.CPU
@@ -190,7 +271,118 @@ func (c *nomadClient) TaskAllocationTotals(capacityUsed *ClusterAllocation) erro
 			}
 		}
 	}
+
 	return nil
+}
+
+// MostUtilizedResource calculates the resource that is most-utilized across the cluster.
+// This is used to determine the resource that should be prioritized when making scaling
+// decisions like determining the least-allocated worker node.
+//
+// If all resources are completely unutilized, the scaling metric will be set to `None`
+// and the daemon will take no actions.
+func (c *nomadClient) MostUtilizedResource(alloc *ClusterAllocation) {
+	// Determine the resource that is consuming the greatest percentage of its overall cluster
+	// capacity.
+	max := (Max(alloc.UsedCapacity.CPUPercent, alloc.UsedCapacity.MemoryPercent,
+		alloc.UsedCapacity.DiskPercent))
+
+	// Set the compute cluster scaling metric to the most-utilized resource.
+	switch max {
+	case 0:
+		alloc.ScalingMetric = ScalingMetricNone
+	case alloc.UsedCapacity.CPUPercent:
+		alloc.ScalingMetric = ScalingMetricProcessor
+	case alloc.UsedCapacity.DiskPercent:
+		alloc.ScalingMetric = ScalingMetricDisk
+	case alloc.UsedCapacity.MemoryPercent:
+		alloc.ScalingMetric = ScalingMetricMemory
+	}
+}
+
+// LeastAllocatedNode determines which worker node is consuming the lowest percentage of the
+// resource identified as the most-utilized resource across the cluster. Since Nomad follows
+// a bin-packing approach, when we need to remove a worker node in response to a scale-in
+// activity, we want to identify the least-allocated node and target it for removal.
+func (c *nomadClient) LeastAllocatedNode(clusterInfo *ClusterAllocation) (node string) {
+	var lowestAllocation float64
+
+	for _, nodeAlloc := range clusterInfo.NodeAllocations {
+		switch clusterInfo.ScalingMetric {
+		case ScalingMetricProcessor:
+			if (lowestAllocation == 0) || (nodeAlloc.UsedCapacity.CPUPercent < lowestAllocation) {
+				node = nodeAlloc.NodeID
+				lowestAllocation = nodeAlloc.UsedCapacity.CPUPercent
+			}
+		case ScalingMetricMemory:
+			if (lowestAllocation == 0) || (nodeAlloc.UsedCapacity.MemoryPercent < lowestAllocation) {
+				node = nodeAlloc.NodeID
+				lowestAllocation = nodeAlloc.UsedCapacity.MemoryPercent
+			}
+		case ScalingMetricDisk:
+			if (lowestAllocation == 0) || (nodeAlloc.UsedCapacity.DiskPercent < lowestAllocation) {
+				node = nodeAlloc.NodeID
+				lowestAllocation = nodeAlloc.UsedCapacity.DiskPercent
+			}
+		}
+	}
+
+	return
+}
+
+// DrainNode toggles the drain mode of a worker node. When enabled, no further allocations
+// will be assigned and existing allocations will be migrated.
+func (c *nomadClient) DrainNode(nodeID string) (err error) {
+	// Initiate allocation draining for specified node.
+	_, err = c.nomad.Nodes().ToggleDrain(nodeID, true, &nomad.WriteOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Validate node has been placed in drain mode; fail fast if the node
+	// failed to enter drain mode.
+	resp, _, err := c.nomad.Nodes().Info(nodeID, &nomad.QueryOptions{})
+	if (err != nil) || (resp.Drain != true) {
+		return err
+	}
+	fmt.Printf("node %v has been placed in drain mode\n", nodeID)
+
+	// Setup a ticker to poll the node allocations and report when all existing
+	// allocations have been migrated to other worker nodes.
+	ticker := time.NewTicker(time.Millisecond * 500)
+	timeout := time.Tick(time.Minute * 3)
+
+	for {
+		select {
+		case <-timeout:
+			fmt.Printf("timeout %v reached while waiting for existing allocations to be migrated from node %v\n",
+				timeout, nodeID)
+			return nil
+		case <-ticker.C:
+			activeAllocations := 0
+
+			// Get allocations assigned to the specified node.
+			allocations, _, err := c.nomad.Nodes().Allocations(nodeID, &nomad.QueryOptions{})
+			if err != nil {
+				return err
+			}
+
+			// Iterate over allocations, if any are running or pending, increment the active
+			// allocations counter.
+			for _, nodeAlloc := range allocations {
+				if (nodeAlloc.ClientStatus == structs.JobStatusRunning) || (nodeAlloc.ClientStatus == structs.JobStatusPending) {
+					activeAllocations++
+				}
+			}
+
+			if activeAllocations == 0 {
+				fmt.Printf("node %v has no active allocations\n", nodeID)
+				return nil
+			}
+
+			fmt.Printf("node %v has %v active allocations, pausing and will re-poll allocations\n", nodeID, activeAllocations)
+		}
+	}
 }
 
 // PercentageCapacityRequired accepts a number of cluster allocation parameters

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -1,4 +1,4 @@
-package api
+package helper
 
 import (
 	"regexp"


### PR DESCRIPTION
This change introduces additional support structures required to make scaling decisions for a Nomad cluster. 

New functionality provides the ability to:
- Calculate the percentage of overall cluster capacity consumed
- Calculate and track per-node consumption of overall cluster capacity 
- Determine the most-utilized resource across the cluster 
- Determine the least-allocated worker node 
- Initiate allocation draining for a worker node

In addition to new functionality, this change reduces the three allocation structs (`totalAllocationCapacity`, `taskAllocation` and `usedAllocationCapacity`) to a single object `AllocationResources` as these structs were tracking the same type of data with the same field names. 

Finally, in order to implement tracking of per-node consumption of overall cluster capacity, the `ClusterAssignedAllocation` method was refactored to determine consumed resources by gathering allocations from each worker node instead of hitting the overall allocations API endpoint. 

Closes [TIOCE-98](https://scival.atlassian.net/browse/TIOCE-98)