### PR TITLE
api/aws: Add AWS Autoscaling API Capability

### DIFF
--- a/api/aws.go
+++ b/api/aws.go
@@ -55,7 +55,7 @@ func ScaleOutCluster(asgName string, svc *autoscaling.AutoScaling) (bool, error)
 	// update to our new desired state.
 	asg, err := DescribeScalingGroup(asgName, svc)
 	if err != nil {
-		return false
+		return false, err
 	}
 
 	// The DesiredCapacity is incramented by 1, while the TerminationPolicies and

--- a/api/aws.go
+++ b/api/aws.go
@@ -1,4 +1,4 @@
-package main
+package api
 
 import (
 	"fmt"
@@ -185,9 +185,4 @@ func terminateInstance(instanceID, region string) error {
 	}
 
 	return nil
-}
-
-func main() {
-	fmt.Println(ScaleInCluster("container_agent-asg-dev", "i-0907b3d40354056d6", NewAWSAsgService("us-east-1")))
-	// fmt.Println(ScaleOutCluster("container_agent-asg-dev", NewAWSAsgService("us-east-1")))
 }

--- a/replicator/structs.go
+++ b/replicator/structs.go
@@ -44,6 +44,10 @@ type ClusterScaling struct {
 	// MinSize is the minimum number of instances that should be present within
 	// the nomad node worker pool.
 	MinSize float64 `mapstructure:"min_size"`
+
+	// CoolDown is the number of seconds after a scaling activity completes before
+	// another can begin.
+	CoolDown float64 `mapstructure:"cool_down"`
 }
 
 // JobScaling is the configuration struct for the Nomad job scaling activities.


### PR DESCRIPTION
Added ability to interface with the AWS autoscaling API to initiate scale-out and scale-in activities in a safe manner and can support the use of a cooldown to prevent thrashing.