### PR TITLE
Add default value for ClusterScaling.CoolDown with conf overrides.

### DIFF
--- a/replicator/config.go
+++ b/replicator/config.go
@@ -19,8 +19,9 @@ func DefaultConfig() *Config {
 		Enforce:  true,
 
 		ClusterScaling: &ClusterScaling{
-			MaxSize: 10,
-			MinSize: 5,
+			MaxSize:  10,
+			MinSize:  5,
+			CoolDown: 300,
 		},
 
 		JobScaling: &JobScaling{
@@ -113,6 +114,9 @@ func (c *Config) Merge(o *Config) {
 		}
 		if o.WasSet("cluster_scaling.min_size") {
 			c.ClusterScaling.MinSize = o.ClusterScaling.MinSize
+		}
+		if o.WasSet("cluster_scaling.cool_down") {
+			c.ClusterScaling.CoolDown = o.ClusterScaling.CoolDown
 		}
 	}
 	if o.WasSet("job_scaling") {

--- a/replicator/config_test.go
+++ b/replicator/config_test.go
@@ -18,8 +18,9 @@ func TestParseConfig_correctDefaulValues(t *testing.T) {
 		Enforce:  true,
 
 		ClusterScaling: &ClusterScaling{
-			MaxSize: 10,
-			MinSize: 5,
+			MaxSize:  10,
+			MinSize:  5,
+			CoolDown: 300,
 		},
 
 		JobScaling: &JobScaling{
@@ -57,8 +58,9 @@ func TestParseConfig_correctNestedPartialOverride(t *testing.T) {
 		Enforce:  true,
 
 		ClusterScaling: &ClusterScaling{
-			MaxSize: 15,
-			MinSize: 5,
+			MaxSize:  15,
+			MinSize:  5,
+			CoolDown: 300,
 		},
 
 		JobScaling: &JobScaling{
@@ -80,8 +82,9 @@ func TestParseConfig_correctFullOverride(t *testing.T) {
     enforce   = false
 
     cluster_scaling {
-      max_size = 1000
-      min_size = 100
+      max_size  = 1000
+      min_size  = 100
+			cool_down = 100
     }
 
     job_scaling {
@@ -108,8 +111,9 @@ func TestParseConfig_correctFullOverride(t *testing.T) {
 		Enforce:  false,
 
 		ClusterScaling: &ClusterScaling{
-			MaxSize: 1000,
-			MinSize: 100,
+			MaxSize:  1000,
+			MinSize:  100,
+			CoolDown: 100,
 		},
 
 		JobScaling: &JobScaling{


### PR DESCRIPTION
The addition of the ClusterScaling.CoolDown configuration param was not match with the appropriate default config value as well as the correct override mechanism for user defined values. This has now been fixed and the tests updated to pass and match the correct behavior.