### PR TITLE
Addition of sample daemon configs for various linux platforms.

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -1,0 +1,15 @@
+# Dist
+
+The `dist` folder contains sample configs for various platforms.
+
+## Assumptions
+
+The examples assume you will either be using replicators default settings or that you will be writing your configuration parameters to `/etc/replicator.d/replicator.hcl` on the filesystem.
+
+## Upstart
+
+On systems using [upstart](http://upstart.ubuntu.com/) the basic upstart file under `upstart/replicator.conf` starts and stops the replicator binary and should be placed under `/etc/init/replicator.conf`. This will then allow you to control the daemon through `start|stop|restart` commands.
+
+## Systemd
+
+On systems using [systemd](https://www.freedesktop.org/wiki/Software/systemd/) the basic systemd unit file under `systemd/replicator.service` starts and stops the replicator daemon and should be placed under `/etc/systemd/system/replicator.service`. This then allows you to control the daemon through `start|stop|restart` commands.

--- a/dist/systemd/replicator.service
+++ b/dist/systemd/replicator.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Replicator
+Documentation=https://github.com/elsevier-core-engineering/replicator
+
+[Service]
+ExecStart=/usr/local/bin/replicator
+SuccessExitStatus=13
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/upstart/replicator.conf
+++ b/dist/upstart/replicator.conf
@@ -1,0 +1,4 @@
+start on (filesystem and net-device-up IFACE=lo)
+stop on runlevel [!2345]
+
+exec /usr/local/bin/replicator


### PR DESCRIPTION
The examples include upstart and systemd and allow users to quickly setup replicator as a system service.