### PR TITLE
Add telemetry setup.

### DIFF
--- a/replicator/cli.go
+++ b/replicator/cli.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"syscall"
 
+	metrics "github.com/armon/go-metrics"
 	"github.com/elsevier-core-engineering/replicator/logging"
 )
 
@@ -18,6 +19,7 @@ const (
 	ExitCodeRunnerError
 	ExitCodeInterrupt
 	ExitCodeParseFlagsError
+	ExitCodeTelemtryError
 )
 
 // CLI is the main entry point for Consulate.
@@ -41,6 +43,16 @@ func (cli *CLI) Run(args []string) int {
 
 	// Set the logging level for the logger.
 	logging.SetLevel(c.LogLevel)
+
+	// Initialize telemetry if this was configured by the user.
+	if c.Telemetry.StatsdAddress != "" {
+		sink, statsErr := metrics.NewStatsdSink(c.Telemetry.StatsdAddress)
+		if statsErr != nil {
+			logging.Error("unable to setup telemetry correctly: %v", statsErr)
+			return ExitCodeTelemtryError
+		}
+		metrics.NewGlobal(metrics.DefaultConfig("replicator"), sink)
+	}
 
 	// Create the initial runner with the merged configuration parameters.
 	runner, err := NewRunner(c)


### PR DESCRIPTION
This PR adds the telemetry setup into the main entry point of replicator and has been tested on a test cluster and statsd endpoint to work correctly and be callable throughout the packages in replicator:

```
$ find ./ -name *.wsp
./runtime/num_goroutines/i-07d997ba0bd21a636.wsp
./runtime/alloc_bytes/i-07d997ba0bd21a636.wsp
./runtime/sys_bytes/i-07d997ba0bd21a636.wsp
./runtime/free_count/i-07d997ba0bd21a636.wsp
./runtime/malloc_count/i-07d997ba0bd21a636.wsp
./runtime/total_gc_runs/i-07d997ba0bd21a636.wsp
./runtime/heap_objects/i-07d997ba0bd21a636.wsp
./runtime/total_gc_pause_ns/i-07d997ba0bd21a636.wsp
./replicator/meaning_of_life/i-07d997ba0bd21a636.wsp
```

The custom gauge set was "meaning_of_life" which can be seen along with the default application metrics.