### PR TITLE
core: add leader safety check to runner 

### DIFF
--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -30,7 +30,7 @@ func NewRunner(config *structs.Config) (*Runner, error) {
 // Start creates a new runner and uses a ticker to block until the doneChan is
 // closed at which point the ticker is stopped.
 func (r *Runner) Start() {
-	ticker := time.NewTicker(time.Second * time.Duration(3))
+	ticker := time.NewTicker(time.Second * time.Duration(10))
 
 	defer ticker.Stop()
 


### PR DESCRIPTION
This change ensures we perform scaling operations only when running on the known leader.