### PR TITLE
Update logging levels on logging messages.

### DIFF
--- a/api/aws.go
+++ b/api/aws.go
@@ -93,7 +93,7 @@ func ScaleOutCluster(asgName string, svc *autoscaling.AutoScaling) error {
 	ticker := time.NewTicker(time.Millisecond * 500)
 	timeout := time.Tick(time.Minute * 3)
 
-	logging.Info("cluster scaling operation (scale-out) will now be verfied, this may take a few minutes...")
+	logging.Info("cluster scaling operation (scale-out) will now be verified, this may take a few minutes...")
 
 	for {
 		select {

--- a/api/aws.go
+++ b/api/aws.go
@@ -93,7 +93,7 @@ func ScaleOutCluster(asgName string, svc *autoscaling.AutoScaling) error {
 	ticker := time.NewTicker(time.Millisecond * 500)
 	timeout := time.Tick(time.Minute * 3)
 
-	logging.Info("cluster scaling operation (scale-out) will now be varified, this may take a few minutes...")
+	logging.Info("cluster scaling operation (scale-out) will now be verfied, this may take a few minutes...")
 
 	for {
 		select {

--- a/api/aws.go
+++ b/api/aws.go
@@ -105,7 +105,7 @@ func ScaleOutCluster(asgName string, svc *autoscaling.AutoScaling) error {
 				logging.Error("an error occurred while attempting to check autoscaling group: %v", err)
 			} else {
 				if len(asg.AutoScalingGroups[0].Instances) == int(newDesiredCapacity) {
-					logging.Info("Scaling operation (scale-out) has been successfully verified")
+					logging.Info("scaling operation (scale-out) has been successfully verified")
 					return nil
 				}
 			}

--- a/api/aws.go
+++ b/api/aws.go
@@ -78,6 +78,8 @@ func ScaleOutCluster(asgName string, svc *autoscaling.AutoScaling) error {
 		TerminationPolicies:  terminationPolicies,
 	}
 
+	logging.Info("cluster scaling (scale-out) will now be initiated")
+
 	// Currently it is assumed that no error received from the API means that the
 	// increase in ASG size has been successful, or at least will be. This may
 	// want to change in the future.
@@ -91,7 +93,7 @@ func ScaleOutCluster(asgName string, svc *autoscaling.AutoScaling) error {
 	ticker := time.NewTicker(time.Millisecond * 500)
 	timeout := time.Tick(time.Minute * 3)
 
-	logging.Info("scaling operation (scale-out) will now be varified, this may take a few minutes...")
+	logging.Info("cluster scaling operation (scale-out) will now be varified, this may take a few minutes...")
 
 	for {
 		select {
@@ -105,7 +107,7 @@ func ScaleOutCluster(asgName string, svc *autoscaling.AutoScaling) error {
 				logging.Error("an error occurred while attempting to check autoscaling group: %v", err)
 			} else {
 				if len(asg.AutoScalingGroups[0].Instances) == int(newDesiredCapacity) {
-					logging.Info("scaling operation (scale-out) has been successfully verified")
+					logging.Info("cluster scaling operation (scale-out) has been successfully verified")
 					return nil
 				}
 			}

--- a/api/nomad.go
+++ b/api/nomad.go
@@ -159,7 +159,7 @@ func (c *nomadClient) CheckClusterScalingSafety(capacity *structs.ClusterAllocat
 	// Determine if performing a scaling operation would violate the scaling cooldown period.
 	if err := CheckClusterScalingTimeThreshold(config.ClusterScaling.CoolDown,
 		config.ClusterScaling.AutoscalingGroup, NewAWSAsgService(config.Region)); err != nil {
-		logging.Info("%v", err)
+		logging.Debug("%v", err)
 		return
 	}
 

--- a/api/nomad.go
+++ b/api/nomad.go
@@ -85,10 +85,9 @@ func (c *nomadClient) EvaluateClusterCapacity(capacity *structs.ClusterAllocatio
 		clusterCapacity = capacity.TotalCapacity.MemoryMB
 	}
 
-	// TODO: Remove temporary logging.
-	logging.Info("Node Count (Min: %v/Max: %v): %v , CPU: %v, Memory: %v", config.ClusterScaling.MinSize,
+	logging.Debug("Node Count (Min: %v/Max: %v): %v , CPU: %v, Memory: %v", config.ClusterScaling.MinSize,
 		config.ClusterScaling.MaxSize, capacity.NodeCount, capacity.TotalCapacity.CPUMHz, capacity.TotalCapacity.MemoryMB)
-	logging.Info("Scaling Metric: %v, Cluster Capacity: %v, Cluster Utilization: %v, Max Allowed: %v",
+	logging.Debug("Scaling Metric: %v, Cluster Capacity: %v, Cluster Utilization: %v, Max Allowed: %v",
 		capacity.ScalingMetric, clusterCapacity, clusterUtilization, capacity.MaxAllowedUtilization)
 
 	// If current utilization is less than max allowed, check to see if we can
@@ -96,10 +95,10 @@ func (c *nomadClient) EvaluateClusterCapacity(capacity *structs.ClusterAllocatio
 	if clusterUtilization < capacity.MaxAllowedUtilization {
 		capacity.ScalingDirection = ScalingDirectionIn
 		if !c.CheckClusterScalingSafety(capacity, config, ScalingDirectionIn) {
-			logging.Info("scaling operation (scale-in) fails to pass the safety check")
+			logging.Debug("scaling operation (scale-in) fails to pass the safety check")
 			return
 		}
-		logging.Info("scaling operation (scale-in) passes the safety check and will be permitted")
+		logging.Debug("scaling operation (scale-in) passes the safety check and will be permitted")
 	}
 
 	// If current utilization is greater than max allowed, check to see if we can
@@ -107,14 +106,14 @@ func (c *nomadClient) EvaluateClusterCapacity(capacity *structs.ClusterAllocatio
 	if clusterUtilization >= capacity.MaxAllowedUtilization {
 		capacity.ScalingDirection = ScalingDirectionOut
 		if !c.CheckClusterScalingSafety(capacity, config, ScalingDirectionOut) {
-			logging.Info("scaling operation (scale-out) fails to pass the safety check")
+			logging.Debug("scaling operation (scale-out) fails to pass the safety check")
 			return
 		}
 
-		logging.Info("scaling operation (scale-out) passes the safety check and will be permitted")
+		logging.Debug("scaling operation (scale-out) passes the safety check and will be permitted")
 	}
 
-	logging.Info("Last Scaling (in api): %v", capacity.LastScalingEvent)
+	logging.Debug("last Scaling (in api): %v", capacity.LastScalingEvent)
 
 	return true, nil
 }
@@ -133,7 +132,7 @@ func (c *nomadClient) CheckClusterScalingSafety(capacity *structs.ClusterAllocat
 	if scaleDirection == ScalingDirectionIn {
 		// Determine if removing a node would violate safety thresholds or declared minimums
 		if (capacity.NodeCount <= 1) || ((capacity.NodeCount - 1) < config.ClusterScaling.MinSize) {
-			logging.Info("scale-in operation would violate safety thresholds or declared minimums")
+			logging.Debug("scale-in operation would violate safety thresholds or declared minimums")
 			return
 		}
 
@@ -147,12 +146,12 @@ func (c *nomadClient) CheckClusterScalingSafety(capacity *structs.ClusterAllocat
 
 		// Evaluate utilization against new maximum allowed threshold and stop if a violation is present.
 		if (clusterUsedCapacity >= newMaxAllowedUtilization) || (newClusterUtilization >= scaleInCapacityThreshold) {
-			logging.Info("scale-in operation would violate or is too close to the maximum allowed cluster utilization threshold")
+			logging.Debug("scale-in operation would violate or is too close to the maximum allowed cluster utilization threshold")
 			return
 		}
 	} else if scaleDirection == ScalingDirectionOut {
 		if (capacity.NodeCount + 1) > config.ClusterScaling.MaxSize {
-			logging.Info("scale-out operation would violate declared maximum threshold")
+			logging.Debug("scale-out operation would violate declared maximum threshold")
 			return
 		}
 	}
@@ -370,7 +369,7 @@ func (c *nomadClient) MostUtilizedGroupResource(gsp *structs.GroupScalingPolicy)
 func (c *nomadClient) LeastAllocatedNode(clusterInfo *structs.ClusterAllocation) (nodeID, nodeIP string) {
 	var lowestAllocation float64
 
-	logging.Info("Scaling Metric: %v", clusterInfo.ScalingMetric)
+	logging.Debug("Scaling Metric: %v", clusterInfo.ScalingMetric)
 	for _, nodeAlloc := range clusterInfo.NodeAllocations {
 		switch clusterInfo.ScalingMetric {
 		case ScalingMetricProcessor:
@@ -478,7 +477,7 @@ func (c *nomadClient) JobScale(scalingDoc *structs.JobScalingPolicy) {
 			for i, taskGroup := range jobResp.TaskGroups {
 				if group.Scaling.ScaleDirection == "Out" && *taskGroup.Count >= group.Scaling.Max ||
 					group.Scaling.ScaleDirection == "In" && *taskGroup.Count <= group.Scaling.Min {
-					logging.Info("scale %v not permitted due to constraints on job \"%v\" and group \"%v\"",
+					logging.Debug("scale %v not permitted due to constraints on job \"%v\" and group \"%v\"",
 						group.Scaling.ScaleDirection, *jobResp.ID, group.GroupName)
 					return
 				}
@@ -629,13 +628,13 @@ func PercentageCapacityRequired(capacity *structs.ClusterAllocation, nodeFailure
 		allocTotal = capacity.TaskAllocation.CPUMHz
 	}
 
-	logging.Info("Capacity Total: %v", capacityTotal)
-	logging.Info("Allocation Total: %v", allocTotal)
-	logging.Info("Node Count: %v", capacity.NodeCount)
+	logging.Debug("Capacity Total: %v", capacityTotal)
+	logging.Debug("Allocation Total: %v", allocTotal)
+	logging.Debug("Node Count: %v", capacity.NodeCount)
 
 	nodeAvgAlloc := float64(capacityTotal / capacity.NodeCount)
-	logging.Info("Node Avg Alloc: %v", nodeAvgAlloc)
-	logging.Info("Node Failure Count: %v", nodeFailureCount)
+	logging.Debug("Node Avg Alloc: %v", nodeAvgAlloc)
+	logging.Debug("Node Failure Count: %v", nodeFailureCount)
 	top := float64((float64(allocTotal)) + (float64(capacityTotal) - (nodeAvgAlloc * float64(nodeFailureCount))))
 	capacityRequired = (top / float64(capacityTotal)) * 100
 
@@ -663,7 +662,7 @@ func MaxAllowedClusterUtilization(capacity *structs.ClusterAllocation, nodeFault
 		capacityTotal = capacityTotal - nodeAvgAlloc
 	}
 
-	logging.Info("Node Average Capacity: %v, Scaling Overhead: %v", nodeAvgAlloc, allocTotal)
+	logging.Debug("node average capacity: %v, scaling overhead: %v", nodeAvgAlloc, allocTotal)
 
 	maxAllowedUtilization = ((capacityTotal - allocTotal) - (nodeAvgAlloc * nodeFaultTolerance))
 

--- a/api/nomad.go
+++ b/api/nomad.go
@@ -482,6 +482,8 @@ func (c *nomadClient) JobScale(scalingDoc *structs.JobScalingPolicy) {
 					return
 				}
 
+				logging.Info("job scaling %v will now be actioned on job \"%v\" and group \"%v\"",
+					group.Scaling.ScaleDirection, scalingDoc.JobName, group.GroupName)
 				// Depending on the scaling direction decrement/incrament the count;
 				// currently replicator only supports addition/subtraction of 1.
 				if *taskGroup.Name == group.GroupName && group.Scaling.ScaleDirection == "Out" {
@@ -494,7 +496,6 @@ func (c *nomadClient) JobScale(scalingDoc *structs.JobScalingPolicy) {
 			}
 		}
 	}
-
 	// Nomad 0.5.5 introduced a Jobs.Validate endpoint within the API package
 	// which validates the job syntax before submition.
 	_, _, err = c.nomad.Jobs().Validate(jobResp, &nomad.WriteOptions{})

--- a/replicator/cli.go
+++ b/replicator/cli.go
@@ -40,6 +40,7 @@ func (cli *CLI) Run(args []string) int {
 
 	c, err := cli.setup(args)
 	if err != nil {
+		logging.Error("unable to setup configuration: %v", err)
 		return ExitCodeParseFlagsError
 	}
 

--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -155,7 +155,7 @@ func (r *Runner) jobScaling() {
 
 		for _, group := range job.GroupScalingPolicies {
 			if group.Scaling.ScaleDirection == "Out" || group.Scaling.ScaleDirection == "In" {
-				logging.Info("scale %v to be requested on job \"%v\" and group \"%v\"", group.Scaling.ScaleDirection, job.JobName, group.GroupName)
+				logging.Debug("scale %v to be requested on job \"%v\" and group \"%v\"", group.Scaling.ScaleDirection, job.JobName, group.GroupName)
 				i++
 			}
 		}

--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -64,7 +64,7 @@ func (r *Runner) clusterScaling(done chan bool) {
 
 	// Determine if we are running on the leader node, halt if not.
 	if haveLeadership := nomadClient.LeaderCheck(); !haveLeadership {
-		logging.Info("replicator is not running on the known leader, no cluster scaling actions will be taken")
+		logging.Debug("replicator is not running on the known leader, no cluster scaling actions will be taken")
 		done <- true
 		return
 	}
@@ -78,7 +78,7 @@ func (r *Runner) clusterScaling(done chan bool) {
 	clusterCapacity := &structs.ClusterAllocation{}
 
 	if scale, err := nomadClient.EvaluateClusterCapacity(clusterCapacity, r.config); err != nil || !scale {
-		logging.Info("scaling operation not required or permitted")
+		logging.Debug("scaling operation not required or permitted")
 	} else {
 		// If we reached this point we will be performing AWS interaction so we
 		// create an client connection.
@@ -86,7 +86,7 @@ func (r *Runner) clusterScaling(done chan bool) {
 
 		if clusterCapacity.ScalingDirection == api.ScalingDirectionOut {
 			if !scalingEnabled {
-				logging.Info("cluster scaling disabled, not initiating scaling operation (scale-out)")
+				logging.Debug("cluster scaling disabled, not initiating scaling operation (scale-out)")
 				done <- true
 				return
 			}
@@ -99,9 +99,8 @@ func (r *Runner) clusterScaling(done chan bool) {
 		if clusterCapacity.ScalingDirection == api.ScalingDirectionIn {
 			nodeID, nodeIP := nomadClient.LeastAllocatedNode(clusterCapacity)
 			if nodeIP != "" && nodeID != "" {
-				logging.Info("NodeIP: %v, NodeID: %v", nodeIP, nodeID)
 				if !scalingEnabled {
-					logging.Info("cluster scaling disabled, not initiating scaling operation (scale-in)")
+					logging.Debug("cluster scaling disabled, not initiating scaling operation (scale-in)")
 					done <- true
 					return
 				}
@@ -132,7 +131,7 @@ func (r *Runner) jobScaling() {
 
 	// Determine if we are running on the leader node, halt if not.
 	if haveLeadership := nomadClient.LeaderCheck(); !haveLeadership {
-		logging.Info("replicator is not running on the known leader, no job scaling actions will be taken")
+		logging.Debug("replicator is not running on the known leader, no job scaling actions will be taken")
 		return
 	}
 


### PR DESCRIPTION
Initially all messages were being logged at Info and above which
causes a lot of noise. All standard messages have now been moved
to debug level so that only messages which change state will be
logged at Info or above.