### PR TITLE
Configuration can now come from a file or directory of files.

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,10 +7,14 @@ import (
 	"github.com/elsevier-core-engineering/replicator/replicator"
 )
 
+var (
+	config string
+)
+
 func init() {
-	// Setup the config CLI flag.
-	var config string
-	flag.StringVar(&config, "config", "", "config file to read overrides")
+
+	// Setup the config CLI flags.
+	flag.StringVar(&config, "config", "", "the relative path to a configuration file or directory")
 	flag.Parse()
 }
 


### PR DESCRIPTION
The -config flag can now be used to configure replicator to use a
single file or a directory which contains a number configuration
files. When a directory is provided, all files are parsed and the
configs merged in lexicographic order.