### PR TITLE
Smarter version details including pre-release details.

### DIFF
--- a/replicator/cli.go
+++ b/replicator/cli.go
@@ -64,7 +64,7 @@ func (cli *CLI) Run(args []string) int {
 		return ExitCodeRunnerError
 	}
 
-	logging.Debug("running version %v", version.GetHumanVersion())
+	logging.Debug("running version %v", version.Get())
 	go runner.Start()
 
 	signalCh := make(chan os.Signal, 1)

--- a/version/version.go
+++ b/version/version.go
@@ -1,8 +1,21 @@
 package version
 
-const humanVersion = "0.0.1"
+import "fmt"
 
-// GetHumanVersion returns a human readable version of replicator.
-func GetHumanVersion() string {
-	return humanVersion
+// The main version number that is being run at the moment.
+const version = "0.0.1"
+
+// A pre-release marker for the version. If this is "" (empty string)
+// then it means that it is a final release. Otherwise, this is a pre-release
+// such as "dev" (in development), "beta", "rc1", etc.
+const versionPrerelease = "dev"
+
+// Get returns a human readable version of replicator.
+func Get() string {
+
+	if versionPrerelease != "" {
+		return fmt.Sprintf("%s-%s", version, versionPrerelease)
+	}
+
+	return version
 }


### PR DESCRIPTION
This now allows replicator to log the version of replicator
including the pre-release currently available making the code
online clearer.