### PR TITLE
Update dist directory to match new replicator config ability.

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -4,12 +4,12 @@ The `dist` folder contains sample configs for various platforms.
 
 ## Assumptions
 
-The examples assume you will either be using replicators default settings or that you will be writing your configuration parameters to `/etc/replicator.d/replicator.hcl` on the filesystem.
+The examples assume you will either be using replicators default settings or that you will be writing your configuration file(s) within `/etc/replicator.d` on the filesystem.
 
 ## Upstart
 
-On systems using [upstart](http://upstart.ubuntu.com/) the basic upstart file under `upstart/replicator.conf` starts and stops the replicator binary and should be placed under `/etc/init/replicator.conf`. This will then allow you to control the daemon through `start|stop|restart` commands.
+On systems using [upstart](http://upstart.ubuntu.com/), the [upstart configuration file](https://github.com/elsevier-core-engineering/replicator/blob/master/dist/upstart/replicator.conf) can be used to control the replicator binary. It should be placed under `/etc/init/replicator.conf`. This will then allow you to control the daemon through `start|stop|restart` commands.
 
 ## Systemd
 
-On systems using [systemd](https://www.freedesktop.org/wiki/Software/systemd/) the basic systemd unit file under `systemd/replicator.service` starts and stops the replicator daemon and should be placed under `/etc/systemd/system/replicator.service`. This then allows you to control the daemon through `start|stop|restart` commands.
+On systems using [systemd](https://www.freedesktop.org/wiki/Software/systemd/), the [basic systemd unit file](https://github.com/elsevier-core-engineering/replicator/blob/master/dist/systemd/replicator.service) can be usd to control the replicator daemon and should be placed under `/etc/systemd/system/replicator.service`. This then allows you to control the daemon through `start|stop|restart` commands.

--- a/dist/systemd/replicator.service
+++ b/dist/systemd/replicator.service
@@ -3,7 +3,7 @@ Description=Replicator
 Documentation=https://github.com/elsevier-core-engineering/replicator
 
 [Service]
-ExecStart=/usr/local/bin/replicator
+ExecStart=/usr/local/bin/replicator -config=/etc/replicator.d/
 SuccessExitStatus=13
 ExecReload=/bin/kill -HUP $MAINPID
 

--- a/dist/upstart/replicator.conf
+++ b/dist/upstart/replicator.conf
@@ -1,4 +1,4 @@
 start on (filesystem and net-device-up IFACE=lo)
 stop on runlevel [!2345]
 
-exec /usr/local/bin/replicator
+exec /usr/local/bin/replicator -config=/etc/replicator.d/


### PR DESCRIPTION
The README has been updated as well as the example upstart and
systemd files to reflect the ability for replicator to read its
configuration using a directory of files.