### PR TITLE
replicator/runner: ensure we do not hang when consul is unavailable

### DIFF
--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -137,7 +137,7 @@ func (r *Runner) jobScaling() {
 
 	// Pull the list of all currently running jobs which have an enabled scaling
 	// document.
-	resp, err := consulClient.ListConsulKV(r.config, nomadClient)
+	resp, err := consulClient.GetJobScalingPolicies(r.config, nomadClient)
 	if err != nil {
 		logging.Error("%v", err)
 	}

--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -136,10 +136,11 @@ func (r *Runner) jobScaling() {
 	}
 
 	// Pull the list of all currently running jobs which have an enabled scaling
-	// document.
+	// document. Fail quickly if we can't retrieve this list.
 	resp, err := consulClient.GetJobScalingPolicies(r.config, nomadClient)
 	if err != nil {
-		logging.Error("%v", err)
+		logging.Error("failed to determine if any jobs have scaling policies enabled \n%v", err)
+		return
 	}
 
 	// EvaluateJobScaling identifies whether each of the Job.Groups requires a

--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -69,6 +69,8 @@ func (r *Runner) clusterScaling(done chan bool) {
 		return
 	}
 
+	// If a region has not been specified, attempt to dynamically determine what
+	// region we are running in.
 	if r.config.Region == "" {
 		if region, err := api.DescribeAWSRegion(); err == nil {
 			r.config.Region = region

--- a/replicator/structs/consul.go
+++ b/replicator/structs/consul.go
@@ -71,8 +71,8 @@ type scalein struct {
 // The ConsulClient interface is used to provide common method signatures for
 // interacting with the Consul API.
 type ConsulClient interface {
-	// ListConsulKV provides a recursed list of Consul KeyValues at the defined
-	// location and can accept an ACL Token if this is enabled on the Consul cluster
-	// being used.
-	ListConsulKV(*Config, NomadClient) ([]*JobScalingPolicy, error)
+	// GetJobScalingPolicies provides a list of Nomad jobs with a defined scaling
+	// policy document at a specified Consuk Key/Value Store location. Supports
+	// the use of an ACL token if required by the Consul cluster.
+	GetJobScalingPolicies(*Config, NomadClient) ([]*JobScalingPolicy, error)
 }


### PR DESCRIPTION
Closes #25 

Unable to reproduce a deadlock when Consul is unavailable but Nomad is running, however, I've added a more detailed error message and ensured the runner will return immediately from `jobScaling` if we are unable to retrieve a list of job scaling policy documents.

This change also renames the `ListConsulKV` method to `GetJobScalingPolicies` to more accurately reflect its purpose as this method contains processing specific to job scaling policy documents. 

**Debug Output**
```
✘  ~/code/go/src/github.com/elsevier-core-engineering/replicator   consul-connection-bug  curl http://localhost:4646/v1/status
404 page not found
 ~/code/go/src/github.com/elsevier-core-engineering/replicator   consul-connection-bug  curl http://localhost:4646/v1/status/leader
"127.0.0.1:4647"%                                                                                                                                                                                   ~/code/go/src/github.com/elsevier-core-engineering/replicator   consul-connection-bug  curl http://localhost:8500/v1/status/leader
curl: (7) Failed to connect to localhost port 8500: Connection refused
 ✘  ~/code/go/src/github.com/elsevier-core-engineering/replicator   consul-connection-bug  go install && replicator -config=/Users/westfaex/Downloads/replicator.config
[DEBUG] running version 0.0.1-dev
[DEBUG] Node Used: 0 (NaN), Cluster Used: 0
[DEBUG] node average capacity: 20000, scaling overhead: 0
[DEBUG] Node Count (Min: 2/Max: 4): 1 , CPU: 20000, Memory: 16384
[DEBUG] Scaling Metric: None, Cluster Capacity: 0, Cluster Utilization: 0, Max Allowed: 0
[DEBUG] scaling operation (scale-out) passes the safety check and will be permitted
[DEBUG] last Scaling (in api): 0001-01-01 00:00:00 +0000 UTC
[DEBUG] cluster scaling disabled, not initiating scaling operation (scale-out)
[ERROR] failed to determine if any jobs have scaling policies enabled
Get http://localhost:8500/v1/kv/tiorap/replicator/config?recurse=: dial tcp 127.0.0.1:8500: getsockopt: connection refused
[DEBUG] Node Used: 0 (NaN), Cluster Used: 0
[DEBUG] node average capacity: 20000, scaling overhead: 0
[DEBUG] Node Count (Min: 2/Max: 4): 1 , CPU: 20000, Memory: 16384
[DEBUG] Scaling Metric: None, Cluster Capacity: 0, Cluster Utilization: 0, Max Allowed: 0
[DEBUG] scaling operation (scale-out) passes the safety check and will be permitted
[DEBUG] last Scaling (in api): 0001-01-01 00:00:00 +0000 UTC
[DEBUG] cluster scaling disabled, not initiating scaling operation (scale-out)
[ERROR] failed to determine if any jobs have scaling policies enabled
Get http://localhost:8500/v1/kv/tiorap/replicator/config?recurse=: dial tcp 127.0.0.1:8500: getsockopt: connection refused
[DEBUG] Node Used: 0 (NaN), Cluster Used: 0
[DEBUG] node average capacity: 20000, scaling overhead: 0
[DEBUG] Node Count (Min: 2/Max: 4): 1 , CPU: 20000, Memory: 16384
[DEBUG] Scaling Metric: None, Cluster Capacity: 0, Cluster Utilization: 0, Max Allowed: 0
```
