### PR TITLE
Rework of Replicator CLI implamentation to use mitchellh/cli.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,24 @@ At present, cluster autoscaling is only supported on AWS but future support for 
 
 A [puppet module](https://github.com/elsevier-core-engineering/puppet-replicator) capable of automatically installing and configuring Replicator is also available.
 
+## Commands
+
+Replicator supports a number of commands (CLI) which allow for the easy control and manipulation of the replicator binary.
+
+### Command: agent
+
+The agent command is the main entry point into Replicator: it runs the agent that handles client or server functionality, including exposing interfaces for client consumption and running jobs. A subset of the available replicator agent configuration can optionally be passed in via CLI arguments:
+
+- -config=<path>: The path to either a single config file or a directory of config files to use for configuring the Replicator agent. Replicator processes configuration files in lexicographic order.
+
+### Command: init
+
+The init command creates an example job scaling document in the current directory. This document can then be manipulated to meet your requirements, or be used to test replicator against the [Nomad init](https://www.nomadproject.io/docs/commands/init.html) example job.
+
+### Command: version
+
+The version command displays build information about the running binary, including the release version.
+
 ## Configuration File Syntax
 
 Replicator uses the [HashiCorp Configuration Language](https://github.com/hashicorp/hcl) for configuration files. By proxy, this means the configuration is also JSON compatible.

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1,0 +1,155 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	metrics "github.com/armon/go-metrics"
+	"github.com/elsevier-core-engineering/replicator/command"
+	"github.com/elsevier-core-engineering/replicator/logging"
+	"github.com/elsevier-core-engineering/replicator/replicator"
+	"github.com/elsevier-core-engineering/replicator/replicator/structs"
+	"github.com/elsevier-core-engineering/replicator/version"
+)
+
+type Command struct {
+	command.Meta
+}
+
+// Help provides the help information for the agent command.
+func (c *Command) Help() string {
+	helpText := `
+  Usage: replicator agent [options]
+
+    Starts the Replicator agent and runs until an interrupt is received.
+    The Replicator agent's configuration primarily comes from the config
+    files used. If no config file is passed, a default config will be
+    used.
+
+  General Options:
+
+    -config=<path>
+      The path to either a single config file or a directory of config
+      files to use for configuring the Replicator agent. Replicator
+      processes configuration files in lexicographic order.
+`
+	return strings.TrimSpace(helpText)
+}
+
+// Synopsis is provides a brief summary of the agent command.
+func (c *Command) Synopsis() string {
+	return "Runs a Replicator agent"
+}
+
+// Run triggers a run of the replicator agent by setting up and parsing the
+// configuration and then initiating a new runner.
+func (c *Command) Run(args []string) int {
+	var config string
+
+	flags := c.Meta.FlagSet("agent", command.FlagSetClient)
+	flags.Usage = func() { c.UI.Output(c.Help()) }
+	flags.StringVar(&config, "config", "", "")
+
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	conf, err := c.setupConfig(args)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("%v", err))
+		return 1
+	}
+
+	// Set the logging level for the logger.
+	logging.SetLevel(conf.LogLevel)
+
+	// Initialize telemetry if this was configured by the user.
+	if conf.Telemetry.StatsdAddress != "" {
+		sink, statsErr := metrics.NewStatsdSink(conf.Telemetry.StatsdAddress)
+		if statsErr != nil {
+			c.UI.Error(fmt.Sprintf("unable to setup telemetry correctly: %v", statsErr))
+			return 1
+		}
+		metrics.NewGlobal(metrics.DefaultConfig("replicator"), sink)
+	}
+
+	// Create the initial runner with the merged configuration parameters.
+	runner, err := replicator.NewRunner(conf)
+	if err != nil {
+		return 1
+	}
+
+	logging.Debug("running version %v", version.Get())
+	go runner.Start()
+
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGQUIT,
+	)
+
+	for {
+		select {
+		case s := <-signalCh:
+			switch s {
+			case syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT:
+				runner.Stop()
+				return 0
+
+			case syscall.SIGHUP:
+				runner.Stop()
+
+				// Reload the configuration in order to make proper use of SIGHUP.
+				c, err := c.setupConfig(args)
+				if err != nil {
+					return 1
+				}
+
+				// Setup a new runner with the new configuration.
+				runner, err = replicator.NewRunner(c)
+				if err != nil {
+					return 1
+				}
+
+				go runner.Start()
+			}
+		}
+	}
+}
+
+// setupConfig asseses the CLI arguments, or lack of, and then iterates through
+// the load order sementics for the configuration to return a configuration
+// object.
+func (c *Command) setupConfig(args []string) (*structs.Config, error) {
+
+	// If the length of the CLI args is greater than one then there is an error.
+	if len(args) > 1 {
+		return nil, fmt.Errorf("too many command line args")
+	}
+
+	// If no cli flags are passed then we just return a default configuration
+	// struct for use.
+	if len(args) == 0 {
+		return DefaultConfig(), nil
+	}
+
+	// If one CLI argument is passed this is split using the equals delimiter and
+	// the right hand side used as the configuration file/path to parse.
+	split := strings.Split(args[0], "=")
+
+	switch p := split[0]; p {
+	case "-config":
+		c, err := FromPath(split[1])
+		if err != nil {
+			return nil, err
+		}
+		return c, nil
+	default:
+		return nil, fmt.Errorf("unable to correctly determine config location %v", split[1])
+	}
+}

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -1,4 +1,4 @@
-package config
+package agent
 
 import (
 	"fmt"
@@ -23,8 +23,6 @@ const (
 
 // DefaultConfig returns a default configuration struct with sane defaults.
 func DefaultConfig() *structs.Config {
-	// var consulClient structs.ConsulClient
-	// var nomadClient structs.NomadClient
 
 	// Instantiate a new Consul client.
 	consulClient, err := api.NewConsulClient(LocalConsulAddress)
@@ -39,8 +37,8 @@ func DefaultConfig() *structs.Config {
 	}
 
 	return &structs.Config{
-		Consul:   "localhost:8500",
-		Nomad:    "http://localhost:4646",
+		Consul:   LocalConsulAddress,
+		Nomad:    LocalNomadAddress,
 		LogLevel: "INFO",
 		Enforce:  true,
 

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -1,4 +1,4 @@
-package config
+package agent
 
 // import (
 // 	"reflect"

--- a/command/init.go
+++ b/command/init.go
@@ -1,0 +1,70 @@
+package command
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+const (
+	// DefaultInitName is the default name we use when
+	// initializing the example file
+	DefaultInitName = "example.json"
+)
+
+type InitCommand struct {
+	Meta
+}
+
+// Help provides the help information for the init command.
+func (c *InitCommand) Help() string {
+	helpText := `
+Usage: replicator init
+
+  Creates an example scaling document that can be used as a
+  starting point to customize further. The example is designed
+  to work with the 'nomad init' job example.
+`
+	return strings.TrimSpace(helpText)
+}
+
+// Synopsis is provides a brief summary of the init command.
+func (c *InitCommand) Synopsis() string {
+	return "Create an example Replicator job scaling document"
+}
+
+// Run triggers the init command to write the example.json file out to the
+// current directory.
+func (c *InitCommand) Run(args []string) int {
+	// Check for misuse
+	if len(args) != 0 {
+		c.UI.Error(c.Help())
+		return 1
+	}
+
+	// Check if the file already exists
+	_, err := os.Stat(DefaultInitName)
+	if err != nil && !os.IsNotExist(err) {
+		c.UI.Error(fmt.Sprintf("Failed to stat '%s': %v", DefaultInitName, err))
+		return 1
+	}
+	if !os.IsNotExist(err) {
+		c.UI.Error(fmt.Sprintf("Scaling document '%s' already exists", DefaultInitName))
+		return 1
+	}
+
+	// Write out the example
+	err = ioutil.WriteFile(DefaultInitName, []byte(defaultScalingDocument), 0660)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Failed to write '%s': %v", DefaultInitName, err))
+		return 1
+	}
+
+	c.UI.Output(fmt.Sprintf("Example scaling document file written to %s", DefaultInitName))
+	return 0
+}
+
+var defaultScalingDocument = strings.TrimSpace(`
+{"enabled":true,"groups":[{"name":"cache","scaling":{"min":1,"max":3,"scaleout":{"cpu":80,"mem":80},"scalein":{"cpu":30,"mem":30}}}]}
+`)

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -1,0 +1,65 @@
+package command
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/cli"
+)
+
+func TestInitCommand_Implements(t *testing.T) {
+	var _ cli.Command = &InitCommand{}
+}
+
+func TestInitCommand_Run(t *testing.T) {
+	ui := new(cli.MockUi)
+	cmd := &InitCommand{Meta: Meta{UI: ui}}
+
+	// Fails on misuse
+	if code := cmd.Run([]string{"some", "bad", "args"}); code != 1 {
+		t.Fatalf("expect exit code 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, cmd.Help()) {
+		t.Fatalf("expect help output, got: %s", out)
+	}
+	ui.ErrorWriter.Reset()
+
+	// Ensure we change the cwd back
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.Chdir(origDir)
+
+	// Create a temp dir and change into it
+	dir, err := ioutil.TempDir("", "replicator")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.RemoveAll(dir)
+	if cerr := os.Chdir(dir); cerr != nil {
+		t.Fatalf("cerr: %s", err)
+	}
+
+	// Works if the file doesn't exist
+	if code := cmd.Run([]string{}); code != 0 {
+		t.Fatalf("expect exit code 0, got: %d", code)
+	}
+	content, err := ioutil.ReadFile(DefaultInitName)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if string(content) != defaultScalingDocument {
+		t.Fatalf("unexpected file content\n\n%s", string(content))
+	}
+
+	// Fails if the file exists
+	if code := cmd.Run([]string{}); code != 1 {
+		t.Fatalf("expect exit code 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "exists") {
+		t.Fatalf("expect file exists error, got: %s", out)
+	}
+}

--- a/command/meta.go
+++ b/command/meta.go
@@ -1,0 +1,48 @@
+package command
+
+import (
+	"bufio"
+	"flag"
+	"io"
+
+	"github.com/mitchellh/cli"
+)
+
+// FlagSetFlags is an enum to define what flags are present in the
+// default FlagSet returned by Meta.FlagSet.
+type FlagSetFlags uint
+
+const (
+	FlagSetNone    FlagSetFlags = 0
+	FlagSetClient  FlagSetFlags = 1 << iota
+	FlagSetDefault              = FlagSetClient
+)
+
+// Meta contains the meta-options and functionality that nearly every
+// Nomad command inherits.
+type Meta struct {
+	UI cli.Ui
+}
+
+// FlagSet returns a FlagSet with the common flags that every
+// command implements. The exact behavior of FlagSet can be configured
+// using the flags as the second parameter, for example to disable
+// server settings on the commands that don't talk to a server.
+func (m *Meta) FlagSet(n string, fs FlagSetFlags) *flag.FlagSet {
+	f := flag.NewFlagSet(n, flag.ContinueOnError)
+
+	// Create an io.Writer that writes to our UI properly for errors.
+	// This is kind of a hack, but it does the job. Basically: create
+	// a pipe, use a scanner to break it into lines, and output each line
+	// to the UI. Do this forever.
+	errR, errW := io.Pipe()
+	errScanner := bufio.NewScanner(errR)
+	go func() {
+		for errScanner.Scan() {
+			m.UI.Error(errScanner.Text())
+		}
+	}()
+	f.SetOutput(errW)
+
+	return f
+}

--- a/command/version.go
+++ b/command/version.go
@@ -1,0 +1,43 @@
+package command
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/mitchellh/cli"
+)
+
+// VersionCommand is a Command implementation that prints the version.
+type VersionCommand struct {
+	Revision          string
+	Version           string
+	VersionPrerelease string
+	UI                cli.Ui
+}
+
+// Help provides the help information for the version command.
+func (c *VersionCommand) Help() string {
+	return ""
+}
+
+// Synopsis is provides a brief summary of the version command.
+func (c *VersionCommand) Synopsis() string {
+	return "Prints the Replicator version"
+}
+
+// Run executes the version command.
+func (c *VersionCommand) Run(_ []string) int {
+	var versionString bytes.Buffer
+
+	fmt.Fprintf(&versionString, "Replicator v%s", c.Version)
+	if c.VersionPrerelease != "" {
+		fmt.Fprintf(&versionString, "-%s", c.VersionPrerelease)
+
+		if c.Revision != "" {
+			fmt.Fprintf(&versionString, " (%s)", c.Revision)
+		}
+	}
+
+	c.UI.Output(versionString.String())
+	return 0
+}

--- a/command/version_test.go
+++ b/command/version_test.go
@@ -1,0 +1,11 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/mitchellh/cli"
+)
+
+func TestVersionCommand_implements(t *testing.T) {
+	var _ cli.Command = &VersionCommand{}
+}

--- a/commands.go
+++ b/commands.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"os"
+
+	"github.com/elsevier-core-engineering/replicator/command"
+	"github.com/elsevier-core-engineering/replicator/command/agent"
+	"github.com/elsevier-core-engineering/replicator/version"
+	"github.com/mitchellh/cli"
+)
+
+// Commands returns the mapping of CLI commands for Replicator. The meta
+// parameter lets you set meta options for all commands.
+func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
+	if metaPtr == nil {
+		metaPtr = new(command.Meta)
+	}
+
+	meta := *metaPtr
+	if meta.UI == nil {
+		meta.UI = &cli.BasicUi{
+			Reader:      os.Stdin,
+			Writer:      os.Stdout,
+			ErrorWriter: os.Stderr,
+		}
+	}
+
+	return map[string]cli.CommandFactory{
+		"agent": func() (cli.Command, error) {
+			return &agent.Command{
+				Meta: meta,
+			}, nil
+		},
+		"init": func() (cli.Command, error) {
+			return &command.InitCommand{
+				Meta: meta,
+			}, nil
+		},
+		"version": func() (cli.Command, error) {
+			ver := version.Version
+			rel := version.VersionPrerelease
+
+			if rel == "" && version.VersionPrerelease != "" {
+				rel = "dev"
+			}
+
+			return &command.VersionCommand{
+				Version:           ver,
+				VersionPrerelease: rel,
+				UI:                meta.UI,
+			}, nil
+		},
+	}
+}

--- a/dist/systemd/replicator.service
+++ b/dist/systemd/replicator.service
@@ -3,7 +3,7 @@ Description=Replicator
 Documentation=https://github.com/elsevier-core-engineering/replicator
 
 [Service]
-ExecStart=/usr/local/bin/replicator -config=/etc/replicator.d/
+ExecStart=/usr/local/bin/replicator agent -config=/etc/replicator.d/
 SuccessExitStatus=13
 ExecReload=/bin/kill -HUP $MAINPID
 

--- a/dist/upstart/replicator.conf
+++ b/dist/upstart/replicator.conf
@@ -1,4 +1,4 @@
 start on (filesystem and net-device-up IFACE=lo)
 stop on runlevel [!2345]
 
-exec /usr/local/bin/replicator -config=/etc/replicator.d/
+exec /usr/local/bin/replicator agent -config=/etc/replicator.d/

--- a/main.go
+++ b/main.go
@@ -1,24 +1,56 @@
 package main
 
 import (
-	"flag"
+	"fmt"
 	"os"
 
-	"github.com/elsevier-core-engineering/replicator/replicator"
+	"github.com/mitchellh/cli"
 )
-
-var (
-	config string
-)
-
-func init() {
-
-	// Setup the config CLI flags.
-	flag.StringVar(&config, "config", "", "the relative path to a configuration file or directory")
-	flag.Parse()
-}
 
 func main() {
-	cli := replicator.NewCLI()
-	os.Exit(cli.Run(os.Args[1:]))
+	os.Exit(Run(os.Args[1:]))
+}
+
+// Run sets up the commands and triggers RunCustom which inacts the correct
+// run of Replicator.
+func Run(args []string) int {
+	return RunCustom(args, Commands(nil))
+}
+
+// RunCustom is the main function to trigger a run of Replicator.
+func RunCustom(args []string, commands map[string]cli.CommandFactory) int {
+	// Get the command line args. We shortcut "--version" and "-v" to
+	// just show the version.
+	for _, arg := range args {
+		if arg == "-v" || arg == "-version" || arg == "--version" {
+			newArgs := make([]string, len(args)+1)
+			newArgs[0] = "version"
+			copy(newArgs[1:], args)
+			args = newArgs
+			break
+		}
+	}
+
+	// Build the commands to include in the help now.
+	commandsInclude := make([]string, 0, len(commands))
+	for k := range commands {
+		switch k {
+		default:
+			commandsInclude = append(commandsInclude, k)
+		}
+	}
+
+	cli := &cli.CLI{
+		Args:     args,
+		Commands: commands,
+		HelpFunc: cli.FilteredHelpFunc(commandsInclude, cli.BasicHelpFunc("replicator")),
+	}
+
+	exitCode, err := cli.Run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error executing CLI: %s\n", err.Error())
+		return 1
+	}
+
+	return exitCode
 }

--- a/replicator/cli.go
+++ b/replicator/cli.go
@@ -1,146 +1,139 @@
 package replicator
 
-import (
-	"fmt"
-	"os"
-	"os/signal"
-	"strings"
-	"syscall"
-
-	metrics "github.com/armon/go-metrics"
-	"github.com/elsevier-core-engineering/replicator/config"
-	"github.com/elsevier-core-engineering/replicator/logging"
-	"github.com/elsevier-core-engineering/replicator/replicator/structs"
-	"github.com/elsevier-core-engineering/replicator/version"
-)
-
-// Setup our exit codes; errors start at 10 for easier debugging.
-const (
-	ExitCodeOK int = 0
-
-	ExitCodeError = 10 + iota
-	ExitCodeRunnerError
-	ExitCodeInterrupt
-	ExitCodeParseConfigError
-	ExitCodeTelemtryError
-)
-
-// CLI is the main entry point for Consulate.
-type CLI struct {
-}
-
-// NewCLI returns the CLI struct.
-func NewCLI() *CLI {
-	return &CLI{}
-}
-
-// Run accepts a slice of command line arguments and ultimatly returns an int
-// which represents the exit code of the command. The function sets up the
-// runner and appropriate configuration and attempts to perform the run.
-func (cli *CLI) Run(args []string) int {
-
-	c, err := cli.setup(args)
-	if err != nil {
-		logging.Error("unable to parse configuration: %v", err)
-		return ExitCodeParseConfigError
-	}
-
-	// Set the logging level for the logger.
-	logging.SetLevel(c.LogLevel)
-
-	// Initialize telemetry if this was configured by the user.
-	if c.Telemetry.StatsdAddress != "" {
-		sink, statsErr := metrics.NewStatsdSink(c.Telemetry.StatsdAddress)
-		if statsErr != nil {
-			logging.Error("unable to setup telemetry correctly: %v", statsErr)
-			return ExitCodeTelemtryError
-		}
-		metrics.NewGlobal(metrics.DefaultConfig("replicator"), sink)
-	}
-
-	// Create the initial runner with the merged configuration parameters.
-	runner, err := NewRunner(c)
-	if err != nil {
-		return ExitCodeRunnerError
-	}
-
-	logging.Debug("running version %v", version.Get())
-	go runner.Start()
-
-	signalCh := make(chan os.Signal, 1)
-	signal.Notify(signalCh,
-		syscall.SIGHUP,
-		syscall.SIGINT,
-		syscall.SIGTERM,
-		syscall.SIGQUIT,
-	)
-
-	for {
-		select {
-		case s := <-signalCh:
-			switch s {
-			case syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT:
-				runner.Stop()
-				return ExitCodeInterrupt
-
-			case syscall.SIGHUP:
-				runner.Stop()
-
-				// Reload the configuration in order to make proper use of SIGHUP.
-				c, err := cli.setup(args)
-				if err != nil {
-					return ExitCodeParseConfigError
-				}
-
-				// Setup a new runner with the new configuration.
-				runner, err = NewRunner(c)
-				if err != nil {
-					return ExitCodeRunnerError
-				}
-
-				go runner.Start()
-			}
-		}
-	}
-}
-
-// setup asseses the CLI arguments, or lack of, and then iterates through
-// the load order sementics for the configuration to return a configuration
-// object.
-func (cli *CLI) setup(args []string) (*structs.Config, error) {
-
-	// If the length of the CLI args is greater than one then there is an error.
-	if len(args) > 1 {
-		return nil, fmt.Errorf("too many command line args\n %v", usage)
-	}
-
-	// If no cli flags are passed then we just return a default configuration
-	// struct for use.
-	if len(args) == 0 {
-		return config.DefaultConfig(), nil
-	}
-
-	// If one CLI argument is passed this is split using the equals delimiter and
-	// the right hand side used as the configuration file/path to parse.
-	split := strings.Split(args[0], "=")
-
-	switch p := split[0]; p {
-	case "-config":
-		c, err := config.FromPath(split[1])
-		if err != nil {
-			return nil, err
-		}
-		return c, nil
-	default:
-		return nil, fmt.Errorf("unable to correctly determine config location %v", split[1])
-	}
-}
-
-const usage = `
-Usage: replicator [options]
-
-Options:
-  -config=<path>
-      The path to a configuration file or directory of configuration files on
-			disk, relative to the current working directory.
-`
+//
+// import (
+// 	"fmt"
+// 	"os"
+// 	"os/signal"
+// 	"strings"
+// 	"syscall"
+//
+// 	metrics "github.com/armon/go-metrics"
+// 	"github.com/elsevier-core-engineering/replicator/config"
+// 	"github.com/elsevier-core-engineering/replicator/logging"
+// 	"github.com/elsevier-core-engineering/replicator/replicator/structs"
+// 	"github.com/elsevier-core-engineering/replicator/version"
+// )
+//
+// // Setup our exit codes; errors start at 10 for easier debugging.
+// const (
+// 	ExitCodeOK int = 0
+//
+// 	ExitCodeError = 10 + iota
+// 	ExitCodeRunnerError
+// 	ExitCodeInterrupt
+// 	ExitCodeParseConfigError
+// 	ExitCodeTelemtryError
+// )
+//
+// // CLI is the main entry point for Consulate.
+// type CLI struct {
+// }
+//
+// // NewCLI returns the CLI struct.
+// func NewCLI() *CLI {
+// 	return &CLI{}
+// }
+//
+// // Run accepts a slice of command line arguments and ultimatly returns an int
+// // which represents the exit code of the command. The function sets up the
+// // runner and appropriate configuration and attempts to perform the run.
+// func (cli *CLI) Run(args []string) int {
+//
+// 	c, err := cli.setup(args)
+// 	if err != nil {
+// 		logging.Error("unable to parse configuration: %v", err)
+// 		return ExitCodeParseConfigError
+// 	}
+//
+// 	// Set the logging level for the logger.
+// 	logging.SetLevel(c.LogLevel)
+//
+// 	// Initialize telemetry if this was configured by the user.
+// 	if c.Telemetry.StatsdAddress != "" {
+// 		sink, statsErr := metrics.NewStatsdSink(c.Telemetry.StatsdAddress)
+// 		if statsErr != nil {
+// 			logging.Error("unable to setup telemetry correctly: %v", statsErr)
+// 			return ExitCodeTelemtryError
+// 		}
+// 		metrics.NewGlobal(metrics.DefaultConfig("replicator"), sink)
+// 	}
+//
+// 	// Create the initial runner with the merged configuration parameters.
+// 	runner, err := NewRunner(c)
+// 	if err != nil {
+// 		return ExitCodeRunnerError
+// 	}
+//
+// 	logging.Debug("running version %v", version.Get())
+// 	go runner.Start()
+//
+// 	signalCh := make(chan os.Signal, 1)
+// 	signal.Notify(signalCh,
+// 		syscall.SIGHUP,
+// 		syscall.SIGINT,
+// 		syscall.SIGTERM,
+// 		syscall.SIGQUIT,
+// 	)
+//
+// 	for {
+// 		select {
+// 		case s := <-signalCh:
+// 			switch s {
+// 			case syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT:
+// 				runner.Stop()
+// 				return ExitCodeInterrupt
+//
+// 			case syscall.SIGHUP:
+// 				runner.Stop()
+//
+// 				// Reload the configuration in order to make proper use of SIGHUP.
+// 				c, err := cli.setup(args)
+// 				if err != nil {
+// 					return ExitCodeParseConfigError
+// 				}
+//
+// 				// Setup a new runner with the new configuration.
+// 				runner, err = NewRunner(c)
+// 				if err != nil {
+// 					return ExitCodeRunnerError
+// 				}
+//
+// 				go runner.Start()
+// 			}
+// 		}
+// 	}
+// }
+//
+// // setup asseses the CLI arguments, or lack of, and then iterates through
+// // the load order sementics for the configuration to return a configuration
+// // object.
+// func (cli *CLI) setup(args []string) (*structs.Config, error) {
+//
+// 	// If the length of the CLI args is greater than one then there is an error.
+// 	if len(args) > 1 {
+// 		return nil, fmt.Errorf("too many command line args\n %v", usage)
+// 	}
+//
+// 	// If no cli flags are passed then we just return a default configuration
+// 	// struct for use.
+// 	if len(args) == 0 {
+// 		return config.DefaultConfig(), nil
+// 	}
+//
+// 	// If one CLI argument is passed this is split using the equals delimiter and
+// 	// the right hand side used as the configuration file/path to parse.
+// 	split := strings.Split(args[0], "=")
+//
+// 	switch p := split[0]; p {
+// 	case "-config":
+// 		c, err := config.FromPath(split[1])
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 		return c, nil
+// 	default:
+// 		return nil, fmt.Errorf("unable to correctly determine config location %v", split[1])
+// 	}
+// }
+//

--- a/vendor/github.com/bgentry/speakeasy/LICENSE_WINDOWS
+++ b/vendor/github.com/bgentry/speakeasy/LICENSE_WINDOWS
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [2013] [the CloudFoundry Authors]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/github.com/bgentry/speakeasy/Readme.md
+++ b/vendor/github.com/bgentry/speakeasy/Readme.md
@@ -1,0 +1,30 @@
+# Speakeasy
+
+This package provides cross-platform Go (#golang) helpers for taking user input
+from the terminal while not echoing the input back (similar to `getpasswd`). The
+package uses syscalls to avoid any dependence on cgo, and is therefore
+compatible with cross-compiling.
+
+[![GoDoc](https://godoc.org/github.com/bgentry/speakeasy?status.png)][godoc]
+
+## Unicode
+
+Multi-byte unicode characters work successfully on Mac OS X. On Windows,
+however, this may be problematic (as is UTF in general on Windows). Other
+platforms have not been tested.
+
+## License
+
+The code herein was not written by me, but was compiled from two separate open
+source packages. Unix portions were imported from [gopass][gopass], while
+Windows portions were imported from the [CloudFoundry Go CLI][cf-cli]'s
+[Windows terminal helpers][cf-ui-windows].
+
+The [license for the windows portion](./LICENSE_WINDOWS) has been copied exactly
+from the source (though I attempted to fill in the correct owner in the
+boilerplate copyright notice).
+
+[cf-cli]: https://github.com/cloudfoundry/cli "CloudFoundry Go CLI"
+[cf-ui-windows]: https://github.com/cloudfoundry/cli/blob/master/src/cf/terminal/ui_windows.go "CloudFoundry Go CLI Windows input helpers"
+[godoc]: https://godoc.org/github.com/bgentry/speakeasy "speakeasy on Godoc.org"
+[gopass]: https://code.google.com/p/gopass "gopass"

--- a/vendor/github.com/bgentry/speakeasy/speakeasy.go
+++ b/vendor/github.com/bgentry/speakeasy/speakeasy.go
@@ -1,0 +1,49 @@
+package speakeasy
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// Ask the user to enter a password with input hidden. prompt is a string to
+// display before the user's input. Returns the provided password, or an error
+// if the command failed.
+func Ask(prompt string) (password string, err error) {
+	return FAsk(os.Stdout, prompt)
+}
+
+// FAsk is the same as Ask, except it is possible to specify the file to write
+// the prompt to. If 'nil' is passed as the writer, no prompt will be written.
+func FAsk(wr io.Writer, prompt string) (password string, err error) {
+	if wr != nil && prompt != "" {
+		fmt.Fprint(wr, prompt) // Display the prompt.
+	}
+	password, err = getPassword()
+
+	// Carriage return after the user input.
+	if wr != nil {
+		fmt.Fprintln(wr, "")
+	}
+	return
+}
+
+func readline() (value string, err error) {
+	var valb []byte
+	var n int
+	b := make([]byte, 1)
+	for {
+		// read one byte at a time so we don't accidentally read extra bytes
+		n, err = os.Stdin.Read(b)
+		if err != nil && err != io.EOF {
+			return "", err
+		}
+		if n == 0 || b[0] == '\n' {
+			break
+		}
+		valb = append(valb, b[0])
+	}
+
+	return strings.TrimSuffix(string(valb), "\r"), nil
+}

--- a/vendor/github.com/bgentry/speakeasy/speakeasy_unix.go
+++ b/vendor/github.com/bgentry/speakeasy/speakeasy_unix.go
@@ -1,0 +1,93 @@
+// based on https://code.google.com/p/gopass
+// Author: johnsiilver@gmail.com (John Doak)
+//
+// Original code is based on code by RogerV in the golang-nuts thread:
+// https://groups.google.com/group/golang-nuts/browse_thread/thread/40cc41e9d9fc9247
+
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package speakeasy
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+)
+
+const sttyArg0 = "/bin/stty"
+
+var (
+	sttyArgvEOff = []string{"stty", "-echo"}
+	sttyArgvEOn  = []string{"stty", "echo"}
+)
+
+// getPassword gets input hidden from the terminal from a user. This is
+// accomplished by turning off terminal echo, reading input from the user and
+// finally turning on terminal echo.
+func getPassword() (password string, err error) {
+	sig := make(chan os.Signal, 10)
+	brk := make(chan bool)
+
+	// File descriptors for stdin, stdout, and stderr.
+	fd := []uintptr{os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd()}
+
+	// Setup notifications of termination signals to channel sig, create a process to
+	// watch for these signals so we can turn back on echo if need be.
+	signal.Notify(sig, syscall.SIGHUP, syscall.SIGINT, syscall.SIGKILL, syscall.SIGQUIT,
+		syscall.SIGTERM)
+	go catchSignal(fd, sig, brk)
+
+	// Turn off the terminal echo.
+	pid, err := echoOff(fd)
+	if err != nil {
+		return "", err
+	}
+
+	// Turn on the terminal echo and stop listening for signals.
+	defer signal.Stop(sig)
+	defer close(brk)
+	defer echoOn(fd)
+
+	syscall.Wait4(pid, nil, 0, nil)
+
+	line, err := readline()
+	if err == nil {
+		password = strings.TrimSpace(line)
+	} else {
+		err = fmt.Errorf("failed during password entry: %s", err)
+	}
+
+	return password, err
+}
+
+// echoOff turns off the terminal echo.
+func echoOff(fd []uintptr) (int, error) {
+	pid, err := syscall.ForkExec(sttyArg0, sttyArgvEOff, &syscall.ProcAttr{Dir: "", Files: fd})
+	if err != nil {
+		return 0, fmt.Errorf("failed turning off console echo for password entry:\n\t%s", err)
+	}
+	return pid, nil
+}
+
+// echoOn turns back on the terminal echo.
+func echoOn(fd []uintptr) {
+	// Turn on the terminal echo.
+	pid, e := syscall.ForkExec(sttyArg0, sttyArgvEOn, &syscall.ProcAttr{Dir: "", Files: fd})
+	if e == nil {
+		syscall.Wait4(pid, nil, 0, nil)
+	}
+}
+
+// catchSignal tries to catch SIGKILL, SIGQUIT and SIGINT so that we can turn
+// terminal echo back on before the program ends. Otherwise the user is left
+// with echo off on their terminal.
+func catchSignal(fd []uintptr, sig chan os.Signal, brk chan bool) {
+	select {
+	case <-sig:
+		echoOn(fd)
+		os.Exit(-1)
+	case <-brk:
+	}
+}

--- a/vendor/github.com/bgentry/speakeasy/speakeasy_windows.go
+++ b/vendor/github.com/bgentry/speakeasy/speakeasy_windows.go
@@ -1,0 +1,41 @@
+// +build windows
+
+package speakeasy
+
+import (
+	"syscall"
+)
+
+// SetConsoleMode function can be used to change value of ENABLE_ECHO_INPUT:
+// http://msdn.microsoft.com/en-us/library/windows/desktop/ms686033(v=vs.85).aspx
+const ENABLE_ECHO_INPUT = 0x0004
+
+func getPassword() (password string, err error) {
+	var oldMode uint32
+
+	err = syscall.GetConsoleMode(syscall.Stdin, &oldMode)
+	if err != nil {
+		return
+	}
+
+	var newMode uint32 = (oldMode &^ ENABLE_ECHO_INPUT)
+
+	err = setConsoleMode(syscall.Stdin, newMode)
+	defer setConsoleMode(syscall.Stdin, oldMode)
+	if err != nil {
+		return
+	}
+
+	return readline()
+}
+
+func setConsoleMode(console syscall.Handle, mode uint32) (err error) {
+	dll := syscall.MustLoadDLL("kernel32")
+	proc := dll.MustFindProc("SetConsoleMode")
+	r, _, err := proc.Call(uintptr(console), uintptr(mode))
+
+	if r == 0 {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/mattn/go-isatty/LICENSE
+++ b/vendor/github.com/mattn/go-isatty/LICENSE
@@ -1,0 +1,9 @@
+Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
+
+MIT License (Expat)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/mattn/go-isatty/README.md
+++ b/vendor/github.com/mattn/go-isatty/README.md
@@ -1,0 +1,37 @@
+# go-isatty
+
+isatty for golang
+
+## Usage
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/mattn/go-isatty"
+	"os"
+)
+
+func main() {
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		fmt.Println("Is Terminal")
+	} else {
+		fmt.Println("Is Not Terminal")
+	}
+}
+```
+
+## Installation
+
+```
+$ go get github.com/mattn/go-isatty
+```
+
+# License
+
+MIT
+
+# Author
+
+Yasuhiro Matsumoto (a.k.a mattn)

--- a/vendor/github.com/mattn/go-isatty/doc.go
+++ b/vendor/github.com/mattn/go-isatty/doc.go
@@ -1,0 +1,2 @@
+// Package isatty implements interface to isatty
+package isatty

--- a/vendor/github.com/mattn/go-isatty/isatty_appengine.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_appengine.go
@@ -1,0 +1,9 @@
+// +build appengine
+
+package isatty
+
+// IsTerminal returns true if the file descriptor is terminal which
+// is always false on on appengine classic which is a sandboxed PaaS.
+func IsTerminal(fd uintptr) bool {
+	return false
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_bsd.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_bsd.go
@@ -1,0 +1,18 @@
+// +build darwin freebsd openbsd netbsd dragonfly
+// +build !appengine
+
+package isatty
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const ioctlReadTermios = syscall.TIOCGETA
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_linux.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_linux.go
@@ -1,0 +1,18 @@
+// +build linux
+// +build !appengine
+
+package isatty
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const ioctlReadTermios = syscall.TCGETS
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_solaris.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_solaris.go
@@ -1,0 +1,16 @@
+// +build solaris
+// +build !appengine
+
+package isatty
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+// see: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c
+func IsTerminal(fd uintptr) bool {
+	var termio unix.Termio
+	err := unix.IoctlSetTermio(int(fd), unix.TCGETA, &termio)
+	return err == nil
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_windows.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_windows.go
@@ -1,0 +1,19 @@
+// +build windows
+// +build !appengine
+
+package isatty
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var kernel32 = syscall.NewLazyDLL("kernel32.dll")
+var procGetConsoleMode = kernel32.NewProc("GetConsoleMode")
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var st uint32
+	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, fd, uintptr(unsafe.Pointer(&st)), 0)
+	return r != 0 && e == 0
+}

--- a/vendor/github.com/mitchellh/cli/LICENSE
+++ b/vendor/github.com/mitchellh/cli/LICENSE
@@ -1,0 +1,354 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. “Contributor”
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. “Contributor Version”
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor’s Contribution.
+
+1.3. “Contribution”
+
+     means Covered Software of a particular Contributor.
+
+1.4. “Covered Software”
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. “Incompatible With Secondary Licenses”
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of version
+        1.1 or earlier of the License, but not also under the terms of a
+        Secondary License.
+
+1.6. “Executable Form”
+
+     means any form of the work other than Source Code Form.
+
+1.7. “Larger Work”
+
+     means a work that combines Covered Software with other material, in a separate
+     file or files, that is not Covered Software.
+
+1.8. “License”
+
+     means this document.
+
+1.9. “Licensable”
+
+     means having the right to grant, to the maximum extent possible, whether at the
+     time of the initial grant or subsequently, any and all of the rights conveyed by
+     this License.
+
+1.10. “Modifications”
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to, deletion
+        from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. “Patent Claims” of a Contributor
+
+      means any patent claim(s), including without limitation, method, process,
+      and apparatus claims, in any patent Licensable by such Contributor that
+      would be infringed, but for the grant of the License, by the making,
+      using, selling, offering for sale, having made, import, or transfer of
+      either its Contributions or its Contributor Version.
+
+1.12. “Secondary License”
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. “Source Code Form”
+
+      means the form of the work preferred for making modifications.
+
+1.14. “You” (or “Your”)
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, “You” includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, “control” means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or as
+        part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its Contributions
+        or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution become
+     effective for each Contribution on the date the Contributor first distributes
+     such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under this
+     License. No additional rights or licenses will be implied from the distribution
+     or licensing of Covered Software under this License. Notwithstanding Section
+     2.1(b) above, no patent license is granted by a Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party’s
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of its
+        Contributions.
+
+     This License does not grant any rights in the trademarks, service marks, or
+     logos of any Contributor (except as may be necessary to comply with the
+     notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this License
+     (see Section 10.2) or under the terms of a Secondary License (if permitted
+     under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its Contributions
+     are its original creation(s) or it has sufficient rights to grant the
+     rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under applicable
+     copyright doctrines of fair use, fair dealing, or other equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under the
+     terms of this License. You must inform recipients that the Source Code Form
+     of the Covered Software is governed by the terms of this License, and how
+     they can obtain a copy of this License. You may not attempt to alter or
+     restrict the recipients’ rights in the Source Code Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this License,
+        or sublicense it under different terms, provided that the license for
+        the Executable Form does not attempt to limit or alter the recipients’
+        rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for the
+     Covered Software. If the Larger Work is a combination of Covered Software
+     with a work governed by one or more Secondary Licenses, and the Covered
+     Software is not Incompatible With Secondary Licenses, this License permits
+     You to additionally distribute such Covered Software under the terms of
+     such Secondary License(s), so that the recipient of the Larger Work may, at
+     their option, further distribute the Covered Software under the terms of
+     either this License or such Secondary License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices (including
+     copyright notices, patent notices, disclaimers of warranty, or limitations
+     of liability) contained within the Source Code Form of the Covered
+     Software, except that You may alter any license notices to the extent
+     required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on behalf
+     of any Contributor. You must make it absolutely clear that any such
+     warranty, support, indemnity, or liability obligation is offered by You
+     alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute, judicial
+   order, or regulation then You must: (a) comply with the terms of this License
+   to the maximum extent possible; and (b) describe the limitations and the code
+   they affect. Such description must be placed in a text file included with all
+   distributions of the Covered Software under this License. Except to the
+   extent prohibited by statute or regulation, such description must be
+   sufficiently detailed for a recipient of ordinary skill to be able to
+   understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+     if such Contributor fails to notify You of the non-compliance by some
+     reasonable means prior to 60 days after You have come back into compliance.
+     Moreover, Your grants from a particular Contributor are reinstated on an
+     ongoing basis if such Contributor notifies You of the non-compliance by
+     some reasonable means, this is the first time You have received notice of
+     non-compliance with this License from such Contributor, and You become
+     compliant prior to 30 days after Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions, counter-claims,
+     and cross-claims) alleging that a Contributor Version directly or
+     indirectly infringes any patent, then the rights granted to You by any and
+     all Contributors for the Covered Software under Section 2.1 of this License
+     shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an “as is” basis, without
+   warranty of any kind, either expressed, implied, or statutory, including,
+   without limitation, warranties that the Covered Software is free of defects,
+   merchantable, fit for a particular purpose or non-infringing. The entire
+   risk as to the quality and performance of the Covered Software is with You.
+   Should any Covered Software prove defective in any respect, You (not any
+   Contributor) assume the cost of any necessary servicing, repair, or
+   correction. This disclaimer of warranty constitutes an essential part of this
+   License. No use of  any Covered Software is authorized under this License
+   except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from such
+   party’s negligence to the extent applicable law prohibits such limitation.
+   Some jurisdictions do not allow the exclusion or limitation of incidental or
+   consequential damages, so this exclusion and limitation may not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts of
+   a jurisdiction where the defendant maintains its principal place of business
+   and such litigation shall be governed by laws of that jurisdiction, without
+   reference to its conflict-of-law provisions. Nothing in this Section shall
+   prevent a party’s ability to bring cross-claims or counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject matter
+   hereof. If any provision of this License is held to be unenforceable, such
+   provision shall be reformed only to the extent necessary to make it
+   enforceable. Any law or regulation which provides that the language of a
+   contract shall be construed against the drafter shall not be used to construe
+   this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version of
+      the License under which You originally received the Covered Software, or
+      under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a modified
+      version of this License if you rename the license and remove any
+      references to the name of the license steward (except to note that such
+      modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+      If You choose to distribute Source Code Form that is Incompatible With
+      Secondary Licenses under the terms of this version of the License, the
+      notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then
+You may include the notice in a location (such as a LICENSE file in a relevant
+directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+      This Source Code Form is “Incompatible
+      With Secondary Licenses”, as defined by
+      the Mozilla Public License, v. 2.0.
+

--- a/vendor/github.com/mitchellh/cli/Makefile
+++ b/vendor/github.com/mitchellh/cli/Makefile
@@ -1,0 +1,20 @@
+TEST?=./...
+
+default: test
+
+# test runs the test suite and vets the code
+test:
+	go list $(TEST) | xargs -n1 go test -timeout=60s -parallel=10 $(TESTARGS)
+
+# testrace runs the race checker
+testrace:
+	go list $(TEST) | xargs -n1 go test -race $(TESTARGS)
+
+# updatedeps installs all the dependencies to run and build
+updatedeps:
+	go list ./... \
+		| xargs go list -f '{{ join .Deps "\n" }}{{ printf "\n" }}{{ join .TestImports "\n" }}' \
+		| grep -v github.com/mitchellh/cli \
+		| xargs go get -f -u -v
+
+.PHONY: test testrace updatedeps

--- a/vendor/github.com/mitchellh/cli/README.md
+++ b/vendor/github.com/mitchellh/cli/README.md
@@ -1,0 +1,63 @@
+# Go CLI Library [![GoDoc](https://godoc.org/github.com/mitchellh/cli?status.png)](https://godoc.org/github.com/mitchellh/cli)
+
+cli is a library for implementing powerful command-line interfaces in Go.
+cli is the library that powers the CLI for
+[Packer](https://github.com/mitchellh/packer),
+[Serf](https://github.com/hashicorp/serf),
+[Consul](https://github.com/hashicorp/consul),
+[Terraform](https://github.com/hashicorp/terraform), and
+[Nomad](https://github.com/hashicorp/nomad).
+
+## Features
+
+* Easy sub-command based CLIs: `cli foo`, `cli bar`, etc.
+
+* Support for nested subcommands such as `cli foo bar`.
+
+* Optional support for default subcommands so `cli` does something
+  other than error.
+
+* Automatic help generation for listing subcommands
+
+* Automatic help flag recognition of `-h`, `--help`, etc.
+
+* Automatic version flag recognition of `-v`, `--version`.
+
+* Helpers for interacting with the terminal, such as outputting information,
+  asking for input, etc. These are optional, you can always interact with the
+  terminal however you choose.
+
+* Use of Go interfaces/types makes augmenting various parts of the library a
+  piece of cake.
+
+## Example
+
+Below is a simple example of creating and running a CLI
+
+```go
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/mitchellh/cli"
+)
+
+func main() {
+	c := cli.NewCLI("app", "1.0.0")
+	c.Args = os.Args[1:]
+	c.Commands = map[string]cli.CommandFactory{
+		"foo": fooCommandFactory,
+		"bar": barCommandFactory,
+	}
+
+	exitStatus, err := c.Run()
+	if err != nil {
+		log.Println(err)
+	}
+
+	os.Exit(exitStatus)
+}
+```
+

--- a/vendor/github.com/mitchellh/cli/cli.go
+++ b/vendor/github.com/mitchellh/cli/cli.go
@@ -1,0 +1,460 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"text/template"
+
+	"github.com/armon/go-radix"
+)
+
+// CLI contains the state necessary to run subcommands and parse the
+// command line arguments.
+//
+// CLI also supports nested subcommands, such as "cli foo bar". To use
+// nested subcommands, the key in the Commands mapping below contains the
+// full subcommand. In this example, it would be "foo bar".
+//
+// If you use a CLI with nested subcommands, some semantics change due to
+// ambiguities:
+//
+//   * We use longest prefix matching to find a matching subcommand. This
+//     means if you register "foo bar" and the user executes "cli foo qux",
+//     the "foo" commmand will be executed with the arg "qux". It is up to
+//     you to handle these args. One option is to just return the special
+//     help return code `RunResultHelp` to display help and exit.
+//
+//   * The help flag "-h" or "-help" will look at all args to determine
+//     the help function. For example: "otto apps list -h" will show the
+//     help for "apps list" but "otto apps -h" will show it for "apps".
+//     In the normal CLI, only the first subcommand is used.
+//
+//   * The help flag will list any subcommands that a command takes
+//     as well as the command's help itself. If there are no subcommands,
+//     it will note this. If the CLI itself has no subcommands, this entire
+//     section is omitted.
+//
+//   * Any parent commands that don't exist are automatically created as
+//     no-op commands that just show help for other subcommands. For example,
+//     if you only register "foo bar", then "foo" is automatically created.
+//
+type CLI struct {
+	// Args is the list of command-line arguments received excluding
+	// the name of the app. For example, if the command "./cli foo bar"
+	// was invoked, then Args should be []string{"foo", "bar"}.
+	Args []string
+
+	// Commands is a mapping of subcommand names to a factory function
+	// for creating that Command implementation. If there is a command
+	// with a blank string "", then it will be used as the default command
+	// if no subcommand is specified.
+	//
+	// If the key has a space in it, this will create a nested subcommand.
+	// For example, if the key is "foo bar", then to access it our CLI
+	// must be accessed with "./cli foo bar". See the docs for CLI for
+	// notes on how this changes some other behavior of the CLI as well.
+	Commands map[string]CommandFactory
+
+	// Name defines the name of the CLI.
+	Name string
+
+	// Version of the CLI.
+	Version string
+
+	// HelpFunc and HelpWriter are used to output help information, if
+	// requested.
+	//
+	// HelpFunc is the function called to generate the generic help
+	// text that is shown if help must be shown for the CLI that doesn't
+	// pertain to a specific command.
+	//
+	// HelpWriter is the Writer where the help text is outputted to. If
+	// not specified, it will default to Stderr.
+	HelpFunc   HelpFunc
+	HelpWriter io.Writer
+
+	once           sync.Once
+	commandTree    *radix.Tree
+	commandNested  bool
+	isHelp         bool
+	subcommand     string
+	subcommandArgs []string
+	topFlags       []string
+
+	isVersion bool
+}
+
+// NewClI returns a new CLI instance with sensible defaults.
+func NewCLI(app, version string) *CLI {
+	return &CLI{
+		Name:     app,
+		Version:  version,
+		HelpFunc: BasicHelpFunc(app),
+	}
+
+}
+
+// IsHelp returns whether or not the help flag is present within the
+// arguments.
+func (c *CLI) IsHelp() bool {
+	c.once.Do(c.init)
+	return c.isHelp
+}
+
+// IsVersion returns whether or not the version flag is present within the
+// arguments.
+func (c *CLI) IsVersion() bool {
+	c.once.Do(c.init)
+	return c.isVersion
+}
+
+// Run runs the actual CLI based on the arguments given.
+func (c *CLI) Run() (int, error) {
+	c.once.Do(c.init)
+
+	// Just show the version and exit if instructed.
+	if c.IsVersion() && c.Version != "" {
+		c.HelpWriter.Write([]byte(c.Version + "\n"))
+		return 1, nil
+	}
+
+	// Attempt to get the factory function for creating the command
+	// implementation. If the command is invalid or blank, it is an error.
+	raw, ok := c.commandTree.Get(c.Subcommand())
+	if !ok {
+		c.HelpWriter.Write([]byte(c.HelpFunc(c.helpCommands(c.subcommandParent())) + "\n"))
+		return 1, nil
+	}
+
+	command, err := raw.(CommandFactory)()
+	if err != nil {
+		return 0, err
+	}
+
+	// If we've been instructed to just print the help, then print it
+	if c.IsHelp() {
+		c.commandHelp(command)
+		return 1, nil
+	}
+
+	// If there is an invalid flag, then error
+	if len(c.topFlags) > 0 {
+		c.HelpWriter.Write([]byte(
+			"Invalid flags before the subcommand. If these flags are for\n" +
+				"the subcommand, please put them after the subcommand.\n\n"))
+		c.commandHelp(command)
+		return 1, nil
+	}
+
+	code := command.Run(c.SubcommandArgs())
+	if code == RunResultHelp {
+		// Requesting help
+		c.commandHelp(command)
+		return 1, nil
+	}
+
+	return code, nil
+}
+
+// Subcommand returns the subcommand that the CLI would execute. For
+// example, a CLI from "--version version --help" would return a Subcommand
+// of "version"
+func (c *CLI) Subcommand() string {
+	c.once.Do(c.init)
+	return c.subcommand
+}
+
+// SubcommandArgs returns the arguments that will be passed to the
+// subcommand.
+func (c *CLI) SubcommandArgs() []string {
+	c.once.Do(c.init)
+	return c.subcommandArgs
+}
+
+// subcommandParent returns the parent of this subcommand, if there is one.
+// If there isn't on, "" is returned.
+func (c *CLI) subcommandParent() string {
+	// Get the subcommand, if it is "" alread just return
+	sub := c.Subcommand()
+	if sub == "" {
+		return sub
+	}
+
+	// Clear any trailing spaces and find the last space
+	sub = strings.TrimRight(sub, " ")
+	idx := strings.LastIndex(sub, " ")
+
+	if idx == -1 {
+		// No space means our parent is root
+		return ""
+	}
+
+	return sub[:idx]
+}
+
+func (c *CLI) init() {
+	if c.HelpFunc == nil {
+		c.HelpFunc = BasicHelpFunc("app")
+
+		if c.Name != "" {
+			c.HelpFunc = BasicHelpFunc(c.Name)
+		}
+	}
+
+	if c.HelpWriter == nil {
+		c.HelpWriter = os.Stderr
+	}
+
+	// Build our command tree
+	c.commandTree = radix.New()
+	c.commandNested = false
+	for k, v := range c.Commands {
+		k = strings.TrimSpace(k)
+		c.commandTree.Insert(k, v)
+		if strings.ContainsRune(k, ' ') {
+			c.commandNested = true
+		}
+	}
+
+	// Go through the key and fill in any missing parent commands
+	if c.commandNested {
+		var walkFn radix.WalkFn
+		toInsert := make(map[string]struct{})
+		walkFn = func(k string, raw interface{}) bool {
+			idx := strings.LastIndex(k, " ")
+			if idx == -1 {
+				// If there is no space, just ignore top level commands
+				return false
+			}
+
+			// Trim up to that space so we can get the expected parent
+			k = k[:idx]
+			if _, ok := c.commandTree.Get(k); ok {
+				// Yay we have the parent!
+				return false
+			}
+
+			// We're missing the parent, so let's insert this
+			toInsert[k] = struct{}{}
+
+			// Call the walk function recursively so we check this one too
+			return walkFn(k, nil)
+		}
+
+		// Walk!
+		c.commandTree.Walk(walkFn)
+
+		// Insert any that we're missing
+		for k := range toInsert {
+			var f CommandFactory = func() (Command, error) {
+				return &MockCommand{
+					HelpText:  "This command is accessed by using one of the subcommands below.",
+					RunResult: RunResultHelp,
+				}, nil
+			}
+
+			c.commandTree.Insert(k, f)
+		}
+	}
+
+	// Process the args
+	c.processArgs()
+}
+
+func (c *CLI) commandHelp(command Command) {
+	// Get the template to use
+	tpl := strings.TrimSpace(defaultHelpTemplate)
+	if t, ok := command.(CommandHelpTemplate); ok {
+		tpl = t.HelpTemplate()
+	}
+	if !strings.HasSuffix(tpl, "\n") {
+		tpl += "\n"
+	}
+
+	// Parse it
+	t, err := template.New("root").Parse(tpl)
+	if err != nil {
+		t = template.Must(template.New("root").Parse(fmt.Sprintf(
+			"Internal error! Failed to parse command help template: %s\n", err)))
+	}
+
+	// Template data
+	data := map[string]interface{}{
+		"Name": c.Name,
+		"Help": command.Help(),
+	}
+
+	// Build subcommand list if we have it
+	var subcommandsTpl []map[string]interface{}
+	if c.commandNested {
+		// Get the matching keys
+		subcommands := c.helpCommands(c.Subcommand())
+		keys := make([]string, 0, len(subcommands))
+		for k := range subcommands {
+			keys = append(keys, k)
+		}
+
+		// Sort the keys
+		sort.Strings(keys)
+
+		// Figure out the padding length
+		var longest int
+		for _, k := range keys {
+			if v := len(k); v > longest {
+				longest = v
+			}
+		}
+
+		// Go through and create their structures
+		subcommandsTpl = make([]map[string]interface{}, 0, len(subcommands))
+		for _, k := range keys {
+			// Get the command
+			raw, ok := subcommands[k]
+			if !ok {
+				c.HelpWriter.Write([]byte(fmt.Sprintf(
+					"Error getting subcommand %q", k)))
+			}
+			sub, err := raw()
+			if err != nil {
+				c.HelpWriter.Write([]byte(fmt.Sprintf(
+					"Error instantiating %q: %s", k, err)))
+			}
+
+			// Find the last space and make sure we only include that last part
+			name := k
+			if idx := strings.LastIndex(k, " "); idx > -1 {
+				name = name[idx+1:]
+			}
+
+			subcommandsTpl = append(subcommandsTpl, map[string]interface{}{
+				"Name":        name,
+				"NameAligned": name + strings.Repeat(" ", longest-len(k)),
+				"Help":        sub.Help(),
+				"Synopsis":    sub.Synopsis(),
+			})
+		}
+	}
+	data["Subcommands"] = subcommandsTpl
+
+	// Write
+	err = t.Execute(c.HelpWriter, data)
+	if err == nil {
+		return
+	}
+
+	// An error, just output...
+	c.HelpWriter.Write([]byte(fmt.Sprintf(
+		"Internal error rendering help: %s", err)))
+}
+
+// helpCommands returns the subcommands for the HelpFunc argument.
+// This will only contain immediate subcommands.
+func (c *CLI) helpCommands(prefix string) map[string]CommandFactory {
+	// If our prefix isn't empty, make sure it ends in ' '
+	if prefix != "" && prefix[len(prefix)-1] != ' ' {
+		prefix += " "
+	}
+
+	// Get all the subkeys of this command
+	var keys []string
+	c.commandTree.WalkPrefix(prefix, func(k string, raw interface{}) bool {
+		// Ignore any sub-sub keys, i.e. "foo bar baz" when we want "foo bar"
+		if !strings.Contains(k[len(prefix):], " ") {
+			keys = append(keys, k)
+		}
+
+		return false
+	})
+
+	// For each of the keys return that in the map
+	result := make(map[string]CommandFactory, len(keys))
+	for _, k := range keys {
+		raw, ok := c.commandTree.Get(k)
+		if !ok {
+			// We just got it via WalkPrefix above, so we just panic
+			panic("not found: " + k)
+		}
+
+		result[k] = raw.(CommandFactory)
+	}
+
+	return result
+}
+
+func (c *CLI) processArgs() {
+	for i, arg := range c.Args {
+		if arg == "--" {
+			break
+		}
+
+		// Check for help flags.
+		if arg == "-h" || arg == "-help" || arg == "--help" {
+			c.isHelp = true
+			continue
+		}
+
+		if c.subcommand == "" {
+			// Check for version flags if not in a subcommand.
+			if arg == "-v" || arg == "-version" || arg == "--version" {
+				c.isVersion = true
+				continue
+			}
+
+			if arg != "" && arg[0] == '-' {
+				// Record the arg...
+				c.topFlags = append(c.topFlags, arg)
+			}
+		}
+
+		// If we didn't find a subcommand yet and this is the first non-flag
+		// argument, then this is our subcommand.
+		if c.subcommand == "" && arg != "" && arg[0] != '-' {
+			c.subcommand = arg
+			if c.commandNested {
+				// Nested CLI, the subcommand is actually the entire
+				// arg list up to a flag that is still a valid subcommand.
+				searchKey := strings.Join(c.Args[i:], " ")
+				k, _, ok := c.commandTree.LongestPrefix(searchKey)
+				if ok {
+					// k could be a prefix that doesn't contain the full
+					// command such as "foo" instead of "foobar", so we
+					// need to verify that we have an entire key. To do that,
+					// we look for an ending in a space or an end of string.
+					reVerify := regexp.MustCompile(regexp.QuoteMeta(k) + `( |$)`)
+					if reVerify.MatchString(searchKey) {
+						c.subcommand = k
+						i += strings.Count(k, " ")
+					}
+				}
+			}
+
+			// The remaining args the subcommand arguments
+			c.subcommandArgs = c.Args[i+1:]
+		}
+	}
+
+	// If we never found a subcommand and support a default command, then
+	// switch to using that.
+	if c.subcommand == "" {
+		if _, ok := c.Commands[""]; ok {
+			args := c.topFlags
+			args = append(args, c.subcommandArgs...)
+			c.topFlags = nil
+			c.subcommandArgs = args
+		}
+	}
+}
+
+const defaultHelpTemplate = `
+{{.Help}}{{if gt (len .Subcommands) 0}}
+
+Subcommands:
+{{ range $value := .Subcommands }}
+    {{ $value.NameAligned }}    {{ $value.Synopsis }}{{ end }}
+{{ end }}
+`

--- a/vendor/github.com/mitchellh/cli/command.go
+++ b/vendor/github.com/mitchellh/cli/command.go
@@ -1,0 +1,47 @@
+package cli
+
+const (
+	// RunResultHelp is a value that can be returned from Run to signal
+	// to the CLI to render the help output.
+	RunResultHelp = -18511
+)
+
+// A command is a runnable sub-command of a CLI.
+type Command interface {
+	// Help should return long-form help text that includes the command-line
+	// usage, a brief few sentences explaining the function of the command,
+	// and the complete list of flags the command accepts.
+	Help() string
+
+	// Run should run the actual command with the given CLI instance and
+	// command-line arguments. It should return the exit status when it is
+	// finished.
+	//
+	// There are a handful of special exit codes this can return documented
+	// above that change behavior.
+	Run(args []string) int
+
+	// Synopsis should return a one-line, short synopsis of the command.
+	// This should be less than 50 characters ideally.
+	Synopsis() string
+}
+
+// CommandHelpTemplate is an extension of Command that also has a function
+// for returning a template for the help rather than the help itself. In
+// this scenario, both Help and HelpTemplate should be implemented.
+//
+// If CommandHelpTemplate isn't implemented, the Help is output as-is.
+type CommandHelpTemplate interface {
+	// HelpTemplate is the template in text/template format to use for
+	// displaying the Help. The keys available are:
+	//
+	//   * ".Help" - The help text itself
+	//   * ".Subcommands"
+	//
+	HelpTemplate() string
+}
+
+// CommandFactory is a type of function that is a factory for commands.
+// We need a factory because we may need to setup some state on the
+// struct that implements the command itself.
+type CommandFactory func() (Command, error)

--- a/vendor/github.com/mitchellh/cli/command_mock.go
+++ b/vendor/github.com/mitchellh/cli/command_mock.go
@@ -1,0 +1,42 @@
+package cli
+
+// MockCommand is an implementation of Command that can be used for tests.
+// It is publicly exported from this package in case you want to use it
+// externally.
+type MockCommand struct {
+	// Settable
+	HelpText     string
+	RunResult    int
+	SynopsisText string
+
+	// Set by the command
+	RunCalled bool
+	RunArgs   []string
+}
+
+func (c *MockCommand) Help() string {
+	return c.HelpText
+}
+
+func (c *MockCommand) Run(args []string) int {
+	c.RunCalled = true
+	c.RunArgs = args
+
+	return c.RunResult
+}
+
+func (c *MockCommand) Synopsis() string {
+	return c.SynopsisText
+}
+
+// MockCommandHelpTemplate is an implementation of CommandHelpTemplate.
+type MockCommandHelpTemplate struct {
+	MockCommand
+
+	// Settable
+	HelpTemplateText string
+}
+
+func (c *MockCommandHelpTemplate) HelpTemplate() string {
+	return c.HelpTemplateText
+}

--- a/vendor/github.com/mitchellh/cli/help.go
+++ b/vendor/github.com/mitchellh/cli/help.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+)
+
+// HelpFunc is the type of the function that is responsible for generating
+// the help output when the CLI must show the general help text.
+type HelpFunc func(map[string]CommandFactory) string
+
+// BasicHelpFunc generates some basic help output that is usually good enough
+// for most CLI applications.
+func BasicHelpFunc(app string) HelpFunc {
+	return func(commands map[string]CommandFactory) string {
+		var buf bytes.Buffer
+		buf.WriteString(fmt.Sprintf(
+			"Usage: %s [--version] [--help] <command> [<args>]\n\n",
+			app))
+		buf.WriteString("Available commands are:\n")
+
+		// Get the list of keys so we can sort them, and also get the maximum
+		// key length so they can be aligned properly.
+		keys := make([]string, 0, len(commands))
+		maxKeyLen := 0
+		for key := range commands {
+			if len(key) > maxKeyLen {
+				maxKeyLen = len(key)
+			}
+
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		for _, key := range keys {
+			commandFunc, ok := commands[key]
+			if !ok {
+				// This should never happen since we JUST built the list of
+				// keys.
+				panic("command not found: " + key)
+			}
+
+			command, err := commandFunc()
+			if err != nil {
+				log.Printf("[ERR] cli: Command '%s' failed to load: %s",
+					key, err)
+				continue
+			}
+
+			key = fmt.Sprintf("%s%s", key, strings.Repeat(" ", maxKeyLen-len(key)))
+			buf.WriteString(fmt.Sprintf("    %s    %s\n", key, command.Synopsis()))
+		}
+
+		return buf.String()
+	}
+}
+
+// FilteredHelpFunc will filter the commands to only include the keys
+// in the include parameter.
+func FilteredHelpFunc(include []string, f HelpFunc) HelpFunc {
+	return func(commands map[string]CommandFactory) string {
+		set := make(map[string]struct{})
+		for _, k := range include {
+			set[k] = struct{}{}
+		}
+
+		filtered := make(map[string]CommandFactory)
+		for k, f := range commands {
+			if _, ok := set[k]; ok {
+				filtered[k] = f
+			}
+		}
+
+		return f(filtered)
+	}
+}

--- a/vendor/github.com/mitchellh/cli/ui.go
+++ b/vendor/github.com/mitchellh/cli/ui.go
@@ -1,0 +1,187 @@
+package cli
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+
+	"github.com/bgentry/speakeasy"
+	"github.com/mattn/go-isatty"
+)
+
+// Ui is an interface for interacting with the terminal, or "interface"
+// of a CLI. This abstraction doesn't have to be used, but helps provide
+// a simple, layerable way to manage user interactions.
+type Ui interface {
+	// Ask asks the user for input using the given query. The response is
+	// returned as the given string, or an error.
+	Ask(string) (string, error)
+
+	// AskSecret asks the user for input using the given query, but does not echo
+	// the keystrokes to the terminal.
+	AskSecret(string) (string, error)
+
+	// Output is called for normal standard output.
+	Output(string)
+
+	// Info is called for information related to the previous output.
+	// In general this may be the exact same as Output, but this gives
+	// Ui implementors some flexibility with output formats.
+	Info(string)
+
+	// Error is used for any error messages that might appear on standard
+	// error.
+	Error(string)
+
+	// Warn is used for any warning messages that might appear on standard
+	// error.
+	Warn(string)
+}
+
+// BasicUi is an implementation of Ui that just outputs to the given
+// writer. This UI is not threadsafe by default, but you can wrap it
+// in a ConcurrentUi to make it safe.
+type BasicUi struct {
+	Reader      io.Reader
+	Writer      io.Writer
+	ErrorWriter io.Writer
+}
+
+func (u *BasicUi) Ask(query string) (string, error) {
+	return u.ask(query, false)
+}
+
+func (u *BasicUi) AskSecret(query string) (string, error) {
+	return u.ask(query, true)
+}
+
+func (u *BasicUi) ask(query string, secret bool) (string, error) {
+	if _, err := fmt.Fprint(u.Writer, query+" "); err != nil {
+		return "", err
+	}
+
+	// Register for interrupts so that we can catch it and immediately
+	// return...
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
+
+	// Ask for input in a go-routine so that we can ignore it.
+	errCh := make(chan error, 1)
+	lineCh := make(chan string, 1)
+	go func() {
+		var line string
+		var err error
+		if secret && isatty.IsTerminal(os.Stdin.Fd()) {
+			line, err = speakeasy.Ask("")
+		} else {
+			r := bufio.NewReader(u.Reader)
+			line, err = r.ReadString('\n')
+		}
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		lineCh <- strings.TrimRight(line, "\r\n")
+	}()
+
+	select {
+	case err := <-errCh:
+		return "", err
+	case line := <-lineCh:
+		return line, nil
+	case <-sigCh:
+		// Print a newline so that any further output starts properly
+		// on a new line.
+		fmt.Fprintln(u.Writer)
+
+		return "", errors.New("interrupted")
+	}
+}
+
+func (u *BasicUi) Error(message string) {
+	w := u.Writer
+	if u.ErrorWriter != nil {
+		w = u.ErrorWriter
+	}
+
+	fmt.Fprint(w, message)
+	fmt.Fprint(w, "\n")
+}
+
+func (u *BasicUi) Info(message string) {
+	u.Output(message)
+}
+
+func (u *BasicUi) Output(message string) {
+	fmt.Fprint(u.Writer, message)
+	fmt.Fprint(u.Writer, "\n")
+}
+
+func (u *BasicUi) Warn(message string) {
+	u.Error(message)
+}
+
+// PrefixedUi is an implementation of Ui that prefixes messages.
+type PrefixedUi struct {
+	AskPrefix       string
+	AskSecretPrefix string
+	OutputPrefix    string
+	InfoPrefix      string
+	ErrorPrefix     string
+	WarnPrefix      string
+	Ui              Ui
+}
+
+func (u *PrefixedUi) Ask(query string) (string, error) {
+	if query != "" {
+		query = fmt.Sprintf("%s%s", u.AskPrefix, query)
+	}
+
+	return u.Ui.Ask(query)
+}
+
+func (u *PrefixedUi) AskSecret(query string) (string, error) {
+	if query != "" {
+		query = fmt.Sprintf("%s%s", u.AskSecretPrefix, query)
+	}
+
+	return u.Ui.AskSecret(query)
+}
+
+func (u *PrefixedUi) Error(message string) {
+	if message != "" {
+		message = fmt.Sprintf("%s%s", u.ErrorPrefix, message)
+	}
+
+	u.Ui.Error(message)
+}
+
+func (u *PrefixedUi) Info(message string) {
+	if message != "" {
+		message = fmt.Sprintf("%s%s", u.InfoPrefix, message)
+	}
+
+	u.Ui.Info(message)
+}
+
+func (u *PrefixedUi) Output(message string) {
+	if message != "" {
+		message = fmt.Sprintf("%s%s", u.OutputPrefix, message)
+	}
+
+	u.Ui.Output(message)
+}
+
+func (u *PrefixedUi) Warn(message string) {
+	if message != "" {
+		message = fmt.Sprintf("%s%s", u.WarnPrefix, message)
+	}
+
+	u.Ui.Warn(message)
+}

--- a/vendor/github.com/mitchellh/cli/ui_colored.go
+++ b/vendor/github.com/mitchellh/cli/ui_colored.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"fmt"
+)
+
+// UiColor is a posix shell color code to use.
+type UiColor struct {
+	Code int
+	Bold bool
+}
+
+// A list of colors that are useful. These are all non-bolded by default.
+var (
+	UiColorNone    UiColor = UiColor{-1, false}
+	UiColorRed             = UiColor{31, false}
+	UiColorGreen           = UiColor{32, false}
+	UiColorYellow          = UiColor{33, false}
+	UiColorBlue            = UiColor{34, false}
+	UiColorMagenta         = UiColor{35, false}
+	UiColorCyan            = UiColor{36, false}
+)
+
+// ColoredUi is a Ui implementation that colors its output according
+// to the given color schemes for the given type of output.
+type ColoredUi struct {
+	OutputColor UiColor
+	InfoColor   UiColor
+	ErrorColor  UiColor
+	WarnColor   UiColor
+	Ui          Ui
+}
+
+func (u *ColoredUi) Ask(query string) (string, error) {
+	return u.Ui.Ask(u.colorize(query, u.OutputColor))
+}
+
+func (u *ColoredUi) AskSecret(query string) (string, error) {
+	return u.Ui.AskSecret(u.colorize(query, u.OutputColor))
+}
+
+func (u *ColoredUi) Output(message string) {
+	u.Ui.Output(u.colorize(message, u.OutputColor))
+}
+
+func (u *ColoredUi) Info(message string) {
+	u.Ui.Info(u.colorize(message, u.InfoColor))
+}
+
+func (u *ColoredUi) Error(message string) {
+	u.Ui.Error(u.colorize(message, u.ErrorColor))
+}
+
+func (u *ColoredUi) Warn(message string) {
+	u.Ui.Warn(u.colorize(message, u.WarnColor))
+}
+
+func (u *ColoredUi) colorize(message string, color UiColor) string {
+	if color.Code == -1 {
+		return message
+	}
+
+	attr := 0
+	if color.Bold {
+		attr = 1
+	}
+
+	return fmt.Sprintf("\033[%d;%dm%s\033[0m", attr, color.Code, message)
+}

--- a/vendor/github.com/mitchellh/cli/ui_concurrent.go
+++ b/vendor/github.com/mitchellh/cli/ui_concurrent.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"sync"
+)
+
+// ConcurrentUi is a wrapper around a Ui interface (and implements that
+// interface) making the underlying Ui concurrency safe.
+type ConcurrentUi struct {
+	Ui Ui
+	l  sync.Mutex
+}
+
+func (u *ConcurrentUi) Ask(query string) (string, error) {
+	u.l.Lock()
+	defer u.l.Unlock()
+
+	return u.Ui.Ask(query)
+}
+
+func (u *ConcurrentUi) AskSecret(query string) (string, error) {
+	u.l.Lock()
+	defer u.l.Unlock()
+
+	return u.Ui.AskSecret(query)
+}
+
+func (u *ConcurrentUi) Error(message string) {
+	u.l.Lock()
+	defer u.l.Unlock()
+
+	u.Ui.Error(message)
+}
+
+func (u *ConcurrentUi) Info(message string) {
+	u.l.Lock()
+	defer u.l.Unlock()
+
+	u.Ui.Info(message)
+}
+
+func (u *ConcurrentUi) Output(message string) {
+	u.l.Lock()
+	defer u.l.Unlock()
+
+	u.Ui.Output(message)
+}
+
+func (u *ConcurrentUi) Warn(message string) {
+	u.l.Lock()
+	defer u.l.Unlock()
+
+	u.Ui.Warn(message)
+}

--- a/vendor/github.com/mitchellh/cli/ui_mock.go
+++ b/vendor/github.com/mitchellh/cli/ui_mock.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// MockUi is a mock UI that is used for tests and is exported publicly for
+// use in external tests if needed as well.
+type MockUi struct {
+	InputReader  io.Reader
+	ErrorWriter  *bytes.Buffer
+	OutputWriter *bytes.Buffer
+
+	once sync.Once
+}
+
+func (u *MockUi) Ask(query string) (string, error) {
+	u.once.Do(u.init)
+
+	var result string
+	fmt.Fprint(u.OutputWriter, query)
+	if _, err := fmt.Fscanln(u.InputReader, &result); err != nil {
+		return "", err
+	}
+
+	return result, nil
+}
+
+func (u *MockUi) AskSecret(query string) (string, error) {
+	return u.Ask(query)
+}
+
+func (u *MockUi) Error(message string) {
+	u.once.Do(u.init)
+
+	fmt.Fprint(u.ErrorWriter, message)
+	fmt.Fprint(u.ErrorWriter, "\n")
+}
+
+func (u *MockUi) Info(message string) {
+	u.Output(message)
+}
+
+func (u *MockUi) Output(message string) {
+	u.once.Do(u.init)
+
+	fmt.Fprint(u.OutputWriter, message)
+	fmt.Fprint(u.OutputWriter, "\n")
+}
+
+func (u *MockUi) Warn(message string) {
+	u.once.Do(u.init)
+
+	fmt.Fprint(u.ErrorWriter, message)
+	fmt.Fprint(u.ErrorWriter, "\n")
+}
+
+func (u *MockUi) init() {
+	u.ErrorWriter = new(bytes.Buffer)
+	u.OutputWriter = new(bytes.Buffer)
+}

--- a/vendor/github.com/mitchellh/cli/ui_writer.go
+++ b/vendor/github.com/mitchellh/cli/ui_writer.go
@@ -1,0 +1,18 @@
+package cli
+
+// UiWriter is an io.Writer implementation that can be used with
+// loggers that writes every line of log output data to a Ui at the
+// Info level.
+type UiWriter struct {
+	Ui Ui
+}
+
+func (w *UiWriter) Write(p []byte) (n int, err error) {
+	n = len(p)
+	if n > 0 && p[n-1] == '\n' {
+		p = p[:n-1]
+	}
+
+	w.Ui.Info(string(p))
+	return n, nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -433,6 +433,12 @@
 			"revisionTime": "2017-03-15T18:41:46Z"
 		},
 		{
+			"checksumSHA1": "6zsRRzJoi5zxQMp6iV/2EraRxPA=",
+			"path": "github.com/mitchellh/cli",
+			"revision": "16bda1254c1d199d9f10a4b90060eda75221a006",
+			"revisionTime": "2017-02-01T16:57:07Z"
+		},
+		{
 			"checksumSHA1": "HQtYvnSHa3OG2tSNMljW8vMvKm4=",
 			"origin": "github.com/hashicorp/nomad/vendor/github.com/mitchellh/copystructure",
 			"path": "github.com/mitchellh/copystructure",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -178,6 +178,12 @@
 			"revisionTime": "2017-03-15T18:41:46Z"
 		},
 		{
+			"checksumSHA1": "Isa9x3nvIJ12hvgdvUUBty+yplU=",
+			"path": "github.com/bgentry/speakeasy",
+			"revision": "675b82c74c0ed12283ee81ba8a534c8982c07b85",
+			"revisionTime": "2016-10-13T10:26:35Z"
+		},
+		{
 			"checksumSHA1": "PiT6aErOEKTly8QgUreblRbCxrY=",
 			"path": "github.com/dariubs/percent",
 			"revision": "6a210960ed74f0c94ad2c45fb5ba2a49b7fd7b1c",
@@ -431,6 +437,12 @@
 			"path": "github.com/jmespath/go-jmespath",
 			"revision": "2b26ad567f305510849d93c5d2025a8b561f2367",
 			"revisionTime": "2017-03-15T18:41:46Z"
+		},
+		{
+			"checksumSHA1": "xZuhljnmBysJPta/lMyYmJdujCg=",
+			"path": "github.com/mattn/go-isatty",
+			"revision": "30a891c33c7cde7b02a981314b4228ec99380cca",
+			"revisionTime": "2016-11-23T14:36:37Z"
 		},
 		{
 			"checksumSHA1": "6zsRRzJoi5zxQMp6iV/2EraRxPA=",

--- a/version/version.go
+++ b/version/version.go
@@ -2,20 +2,20 @@ package version
 
 import "fmt"
 
-// The main version number that is being run at the moment.
-const version = "0.0.1"
+// Version is the main version number that is being run at the moment.
+const Version = "0.0.1"
 
-// A pre-release marker for the version. If this is "" (empty string)
-// then it means that it is a final release. Otherwise, this is a pre-release
-// such as "dev" (in development), "beta", "rc1", etc.
-const versionPrerelease = "dev"
+// VersionPrerelease is a pre-release marker for the version. If this is ""
+// (empty string) then it means that it is a final release. Otherwise, this is
+// a pre-release such as "dev" (in development), "beta", "rc1", etc.
+const VersionPrerelease = "dev"
 
 // Get returns a human readable version of replicator.
 func Get() string {
 
-	if versionPrerelease != "" {
-		return fmt.Sprintf("%s-%s", version, versionPrerelease)
+	if VersionPrerelease != "" {
+		return fmt.Sprintf("%s-%s", Version, VersionPrerelease)
 	}
 
-	return version
+	return Version
 }


### PR DESCRIPTION
command package has now been added where all CLI commands are
configured and replicator now uses github.com/mitchellh/cli for
its top level commands.

This changes also introduces three new commands and removes the
old -config top level command. The commands, init, version, and
agent are now the top level commands which manipulate the
replicator binary.

The README has been updated and the dist example unit files has
been updated to reflect the new changes.

Closes #31 
Closes #37 