### PR TITLE
api/nomad: Detect Dormant Cluster During Scaling Evaluation

### DIFF
--- a/api/nomad.go
+++ b/api/nomad.go
@@ -92,7 +92,7 @@ func (c *nomadClient) EvaluateClusterCapacity(capacity *structs.ClusterAllocatio
 
 	// If current utilization is less than max allowed, check to see if we can
 	// and should scale the cluster in.
-	if clusterUtilization < capacity.MaxAllowedUtilization {
+	if (clusterUtilization < capacity.MaxAllowedUtilization) || (capacity.ScalingMetric == ScalingMetricNone) {
 		capacity.ScalingDirection = ScalingDirectionIn
 		if !c.CheckClusterScalingSafety(capacity, config, ScalingDirectionIn) {
 			logging.Debug("scaling operation (scale-in) fails to pass the safety check")
@@ -103,7 +103,7 @@ func (c *nomadClient) EvaluateClusterCapacity(capacity *structs.ClusterAllocatio
 
 	// If current utilization is greater than max allowed, check to see if we can
 	// and should scale the cluster out.
-	if clusterUtilization >= capacity.MaxAllowedUtilization {
+	if (clusterUtilization >= capacity.MaxAllowedUtilization) && (capacity.ScalingMetric != ScalingDirectionNone) {
 		capacity.ScalingDirection = ScalingDirectionOut
 		if !c.CheckClusterScalingSafety(capacity, config, ScalingDirectionOut) {
 			logging.Debug("scaling operation (scale-out) fails to pass the safety check")


### PR DESCRIPTION
This change will detect when a cluster utilization is 0 for supported metrics (e.g. CPU, Memory). The evaluation method will attempt to initiate scale-in operation whenever the cluster is determined to be dormant thus ensuring we take the cluster down to the declared minimum size. 

The evaluation method short-circuits the scale-out section if the cluster is determined to be dormant.

Closes #38