### PR TITLE
[WIP] Allow Dry Run Operations Against Job Scaling Documents

### DIFF
--- a/api/consul.go
+++ b/api/consul.go
@@ -69,7 +69,7 @@ func (c *consulClient) GetJobScalingPolicies(config *structs.Config, nomadClient
 		// TODO (e.westfall): We should not exclude jobs with scaling disabled as
 		// this prevents users from running in dry-run mode to see what *would*
 		// have happened.
-		if s.Enabled && nomadClient.IsJobRunning(s.JobName) {
+		if nomadClient.IsJobRunning(s.JobName) {
 
 			// Each scaling policy document is then appended to a list to form a full
 			// view of all scaling documents available to the cluster.

--- a/api/nomad.go
+++ b/api/nomad.go
@@ -541,6 +541,7 @@ func (c *nomadClient) GetTaskGroupResources(jobName string, groupPolicy *structs
 func (c *nomadClient) EvaluateJobScaling(jobs []*structs.JobScalingPolicy) {
 	for _, policy := range jobs {
 		for _, gsp := range policy.GroupScalingPolicies {
+			logging.Debug("api/nomad: evaluating scaling for job %v", policy.JobName)
 			c.GetTaskGroupResources(policy.JobName, gsp)
 
 			allocs, _, err := c.nomad.Jobs().Allocations(policy.JobName, false, &nomad.QueryOptions{})


### PR DESCRIPTION
This is a **WIP**, requires additional testing and evaluation. 

This change will modify the `api` package and the `core/runner` to retrieve and evaluate all job scaling documents, even if scaling is set to `disabled` in the policy. 

This will allow users to audit a job scaling policy behavior before allowing the daemon to take action. 


Closes #36 