### PR TITLE
Add the scaling_interval config parameter to replicator agent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ aws_region = "us-east-1"
 # The log level the daemon should use.
 log_level  = "info"
 
+# The time period in seconds between replicator check runs.
+scaling_interval = 10
+
 # This denotes the start of the configuration section for cluster autoscaling.
 cluster_scaling {
   # Indicates whether the daemon should perform scaling actions. If disabled, the actions that would have been taken will be reported in the logs but skipped.
@@ -180,10 +183,6 @@ Replicator will dynamically scale-in the worker pool when:
 
 Replicator will dynamically scale-out the worker pool when:
 - Resource utilization exceeds or closely approaches the capacity required to run all current jobs while sustaining the configured node fault-tolerance. When calculating required capacity, Replicator includes scaling overhead required to increase the count of all running jobs by one.
-
-### How often does Replicator evaluate scaling requirements?
-
-Replicator evaluates cluster capacity and scaling requirements every 10 seconds. At present, this is not configurable but there are plans to add this to the list of configurable options.
 
 ### When does Replicator perform scaling actions against running jobs?
 

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -37,10 +37,11 @@ func DefaultConfig() *structs.Config {
 	}
 
 	return &structs.Config{
-		Consul:   LocalConsulAddress,
-		Nomad:    LocalNomadAddress,
-		LogLevel: "INFO",
-		Enforce:  true,
+		Consul:          LocalConsulAddress,
+		Nomad:           LocalNomadAddress,
+		LogLevel:        "INFO",
+		Enforce:         true,
+		ScalingInterval: 10,
 
 		ClusterScaling: &structs.ClusterScaling{
 			MaxSize:            10,

--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -30,7 +30,7 @@ func NewRunner(config *structs.Config) (*Runner, error) {
 // Start creates a new runner and uses a ticker to block until the doneChan is
 // closed at which point the ticker is stopped.
 func (r *Runner) Start() {
-	ticker := time.NewTicker(time.Second * time.Duration(10))
+	ticker := time.NewTicker(time.Second * time.Duration(r.config.ScalingInterval))
 
 	defer ticker.Stop()
 

--- a/replicator/structs/config.go
+++ b/replicator/structs/config.go
@@ -18,6 +18,10 @@ type Config struct {
 	// actioned, or whether the application runs in report only mode.
 	Enforce bool `mapstructure:"enforce"`
 
+	// ScalingInterval is the duration in seconds between Replicator runs and thus
+	// scaling requirement checks.
+	ScalingInterval int `mapstructure:"scaling_interval"`
+
 	// Region represents the AWS region the cluster resides in.
 	Region string `mapstructure:"aws_region"`
 
@@ -118,6 +122,9 @@ func (c *Config) Merge(o *Config) {
 	}
 	if o.WasSet("enforce") {
 		c.Enforce = o.Enforce
+	}
+	if o.WasSet("scaling_interval") {
+		c.ScalingInterval = o.ScalingInterval
 	}
 	if o.WasSet("cluster_scaling") {
 		if o.WasSet("cluster_scaling.enabled") {


### PR DESCRIPTION
This makes the scaling_interval configurable and therefore allows
users to configure the interval at which replicator agent runs.
The parameter is configured in seconds and the default setting
is set to 10.

Closes #44 