### PR TITLE
Rename api package to client.

### DIFF
--- a/client/aws.go
+++ b/client/aws.go
@@ -1,4 +1,4 @@
-package api
+package client
 
 import (
 	"fmt"

--- a/client/consul.go
+++ b/client/consul.go
@@ -1,4 +1,4 @@
-package api
+package client
 
 import (
 	"encoding/base64"

--- a/client/consul_test.go
+++ b/client/consul_test.go
@@ -1,4 +1,4 @@
-package api
+package client
 
 //
 // import (

--- a/client/nomad.go
+++ b/client/nomad.go
@@ -1,4 +1,4 @@
-package api
+package client
 
 import (
 	"math"

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/elsevier-core-engineering/replicator/api"
+	"github.com/elsevier-core-engineering/replicator/client"
 	"github.com/elsevier-core-engineering/replicator/logging"
 	"github.com/elsevier-core-engineering/replicator/replicator/structs"
 
@@ -25,13 +25,13 @@ const (
 func DefaultConfig() *structs.Config {
 
 	// Instantiate a new Consul client.
-	consulClient, err := api.NewConsulClient(LocalConsulAddress)
+	consulClient, err := client.NewConsulClient(LocalConsulAddress)
 	if err != nil {
 		logging.Error("command/agent: failed to obtain consul connection: %v", err)
 	}
 
 	// Instantiate a new Nomad client.
-	nomadClient, err := api.NewNomadClient(LocalNomadAddress)
+	nomadClient, err := client.NewNomadClient(LocalNomadAddress)
 	if err != nil {
 		logging.Error("command/agent: failed to obtain nomad connection: %v", err)
 	}
@@ -118,14 +118,14 @@ func ParseConfig(path string) (*structs.Config, error) {
 	c = d
 
 	// Instantiate a new Consul client.
-	if consulClient, err := api.NewConsulClient(c.Consul); err == nil {
+	if consulClient, err := client.NewConsulClient(c.Consul); err == nil {
 		c.ConsulClient = consulClient
 	} else {
 		logging.Error("command/agent: failed to establish a new consul client: %v", err)
 	}
 
 	// Instantiate a new Nomad client.
-	if nomadClient, err := api.NewNomadClient(c.Nomad); err == nil {
+	if nomadClient, err := client.NewNomadClient(c.Nomad); err == nil {
 		c.NomadClient = nomadClient
 	} else {
 		logging.Error("command/agent: failed to establish a new nomad client: %v", err)

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -5,7 +5,7 @@ package agent
 // 	"strings"
 // 	"testing"
 //
-// 	"github.com/elsevier-core-engineering/replicator/api"
+// 	"github.com/elsevier-core-engineering/replicator/client"
 // 	"github.com/elsevier-core-engineering/replicator/replicator/structs"
 // 	"github.com/hashicorp/consul-template/test"
 // )
@@ -14,7 +14,7 @@ package agent
 // 	// TODO (e.westfall): Can we call ParseConfig in here to pickup the client
 // 	// instantiation?
 // 	config := DefaultConfig()
-// 	consulClient, _ := api.NewConsulClient("localhost:8500")
+// 	consulClient, _ := client.NewConsulClient("localhost:8500")
 // 	config.ConsulClient = consulClient
 //
 // 	expected := &structs.Config{
@@ -59,7 +59,7 @@ package agent
 // 		t.Fatal(err)
 // 	}
 //
-// 	consulClient, _ := api.NewConsulClient("consul.tiorap.systems:8500")
+// 	consulClient, _ := client.NewConsulClient("consul.tiorap.systems:8500")
 //
 // 	expected := &structs.Config{
 // 		Consul:   "consul.tiorap.systems:8500",


### PR DESCRIPTION
This moves all external API calls and logic from the api package
to the client package. This name makes more sense and is more
consistant with other go packages and allows us to in the future
create an API for replicator.

Closes #42