### PR TITLE
Allow Dry Run Operations Against Job Scaling Documents

### DIFF
--- a/client/consul.go
+++ b/client/consul.go
@@ -69,8 +69,7 @@ func (c *consulClient) GetJobScalingPolicies(config *structs.Config, nomadClient
 		// TODO (e.westfall): We should not exclude jobs with scaling disabled as
 		// this prevents users from running in dry-run mode to see what *would*
 		// have happened.
-		if s.Enabled && nomadClient.IsJobRunning(s.JobName) {
-
+		if nomadClient.IsJobRunning(s.JobName) {
 			// Each scaling policy document is then appended to a list to form a full
 			// view of all scaling documents available to the cluster.
 			entries = append(entries, s)

--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -137,7 +137,7 @@ func (r *Runner) jobScaling() {
 		return
 	}
 
-	// Pull the list of all currently running jobs which have an enabled scaling
+	// Pull the list of all currently running jobs which have a defined scaling
 	// document. Fail quickly if we can't retrieve this list.
 	resp, err := consulClient.GetJobScalingPolicies(r.config, nomadClient)
 	if err != nil {
@@ -157,9 +157,15 @@ func (r *Runner) jobScaling() {
 		i := 0
 
 		for _, group := range job.GroupScalingPolicies {
-			if group.Scaling.ScaleDirection == "Out" || group.Scaling.ScaleDirection == "In" {
-				logging.Debug("core/runner: scale %v to be requested on job \"%v\" and group \"%v\"", group.Scaling.ScaleDirection, job.JobName, group.GroupName)
-				i++
+			if group.Scaling.ScaleDirection == client.ScalingDirectionOut || group.Scaling.ScaleDirection == client.ScalingDirectionIn {
+				if job.Enabled {
+					logging.Debug("core/runner: scaling for job \"%v\" has been enabled; a scaling operation (%v) will be requested for group \"%v\"",
+						job.JobName, group.Scaling.ScaleDirection, group.GroupName)
+					i++
+				} else {
+					logging.Debug("core/runner: scaling for job \"%v\" has been disabled; a scaling operation (%v) would have been requested for group \"%v\"",
+						job.JobName, group.Scaling.ScaleDirection, group.GroupName)
+				}
 			}
 		}
 

--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -159,7 +159,7 @@ func (r *Runner) jobScaling() {
 		for _, group := range job.GroupScalingPolicies {
 			if group.Scaling.ScaleDirection == client.ScalingDirectionOut || group.Scaling.ScaleDirection == client.ScalingDirectionIn {
 				if job.Enabled {
-					logging.Debug("core/runner: scaling for job \"%v\" has been enabled; a scaling operation (%v) will be requested for group \"%v\"",
+					logging.Debug("core/runner: scaling for job \"%v\" is enabled; a scaling operation (%v) will be requested for group \"%v\"",
 						job.JobName, group.Scaling.ScaleDirection, group.GroupName)
 					i++
 				} else {


### PR DESCRIPTION
This change will modify the `client` package and `replicator/runner` to retrieve and evaluate all job scaling documents, even if scaling is set to `disabled` in the policy. 

This will allow users to evaluate the scaling actions Replicator would take without actually impacting the job. 

**Example Dry-Run Output**
```
May  3 21:31:52 ip-10-169-23-100 replicator[10905]: [DEBUG] core/runner: scaling for job "ceapp" has been disabled; a scaling operation (In) would have been requested for group "ceapp"
```

**Actual Scaling Operation**
```
May  3 21:32:02 ip-10-169-23-100 replicator[10905]: [INFO] api/nomad: scaling for job "ceapp" has been enabled; a scaling operation (In) will be requested for group "ceapp"
May  3 21:32:02 ip-10-169-23-100 replicator[10905]: [INFO] api/nomad: scaling action successfully taken against job "ceapp"
```

Closes #36 