### PR TITLE
Prevent Divide By Zero Panic When Replicator Detects No Healthy Worker Nodes

### DIFF
--- a/client/aws.go
+++ b/client/aws.go
@@ -78,7 +78,7 @@ func ScaleOutCluster(asgName string, svc *autoscaling.AutoScaling) error {
 		TerminationPolicies:  terminationPolicies,
 	}
 
-	logging.Info("api/aws: cluster scaling (scale-out) will now be initiated")
+	logging.Info("client/aws: cluster scaling (scale-out) will now be initiated")
 
 	// Currently it is assumed that no error received from the API means that the
 	// increase in ASG size has been successful, or at least will be. This may
@@ -93,21 +93,21 @@ func ScaleOutCluster(asgName string, svc *autoscaling.AutoScaling) error {
 	ticker := time.NewTicker(time.Millisecond * 500)
 	timeout := time.Tick(time.Minute * 3)
 
-	logging.Info("api/aws: cluster scaling operation (scale-out) will now be verified, this may take a few minutes...")
+	logging.Info("client/aws: cluster scaling operation (scale-out) will now be verified, this may take a few minutes...")
 
 	for {
 		select {
 		case <-timeout:
-			logging.Info("api/aws: timeout %v reached while waiting for autoscaling group %v",
+			logging.Info("client/aws: timeout %v reached while waiting for autoscaling group %v",
 				timeout, asgName)
 			return nil
 		case <-ticker.C:
 			asg, err := DescribeScalingGroup(asgName, svc)
 			if err != nil {
-				logging.Error("api/aws: an error occurred while attempting to check autoscaling group: %v", err)
+				logging.Error("client/aws: an error occurred while attempting to check autoscaling group: %v", err)
 			} else {
 				if len(asg.AutoScalingGroups[0].Instances) == int(newDesiredCapacity) {
-					logging.Info("api/aws: cluster scaling operation (scale-out) has been successfully verified")
+					logging.Info("client/aws: cluster scaling operation (scale-out) has been successfully verified")
 					return nil
 				}
 			}
@@ -294,7 +294,7 @@ func translateIptoID(ip, region string) (id string) {
 	resp, err := svc.DescribeInstances(params)
 
 	if err != nil {
-		logging.Error("api/aws: unable to convert nomad instance IP to AWS ID: %v", err)
+		logging.Error("client/aws: unable to convert nomad instance IP to AWS ID: %v", err)
 		return
 	}
 

--- a/client/consul.go
+++ b/client/consul.go
@@ -64,11 +64,8 @@ func (c *consulClient) GetJobScalingPolicies(config *structs.Config, nomadClient
 		// Trim the Key and its trailing slash to find the job name.
 		s.JobName = strings.TrimPrefix(job.Key, config.JobScaling.ConsulKeyLocation+"/")
 
-		// Check to see whether the scaling document is enabled and the job has
-		// running task groups before appending to the return.
-		// TODO (e.westfall): We should not exclude jobs with scaling disabled as
-		// this prevents users from running in dry-run mode to see what *would*
-		// have happened.
+		// Check to see whether the job has running task groups before appending
+		// to the return.
 		if nomadClient.IsJobRunning(s.JobName) {
 			// Each scaling policy document is then appended to a list to form a full
 			// view of all scaling documents available to the cluster.

--- a/client/nomad.go
+++ b/client/nomad.go
@@ -52,14 +52,14 @@ func NewNomadClient(addr string) (structs.NomadClient, error) {
 func (c *nomadClient) EvaluateClusterCapacity(capacity *structs.ClusterAllocation, config *structs.Config) (scalingRequired bool, err error) {
 	var clusterUtilization, clusterCapacity int
 
-	// If there are no healthy cluster nodes, short-circuit the scaling evaluation.
-	if capacity.NodeCount <= 0 {
-		logging.Debug("client/nomad: no healthy nodes detected, halting cluster scaling evaluation")
+	// Determine total cluster capacity.
+	if err = c.ClusterAllocationCapacity(capacity); err != nil {
 		return
 	}
 
-	// Determine total cluster capacity.
-	if err = c.ClusterAllocationCapacity(capacity); err != nil {
+	// If there are no healthy cluster nodes, short-circuit the scaling evaluation.
+	if capacity.NodeCount <= 0 {
+		logging.Debug("client/nomad: no healthy nodes detected, halting cluster scaling evaluation")
 		return
 	}
 

--- a/client/nomad.go
+++ b/client/nomad.go
@@ -91,7 +91,7 @@ func (c *nomadClient) EvaluateClusterCapacity(capacity *structs.ClusterAllocatio
 		clusterCapacity = capacity.TotalCapacity.MemoryMB
 	}
 
-	logging.Debug("api/nomad: Cluster Node Count (Min: %v, Max: %v, Fault Tolerance: %v, Current: %v)",
+	logging.Debug("client/nomad: Cluster Node Count (Min: %v, Max: %v, Fault Tolerance: %v, Current: %v)",
 		config.ClusterScaling.MinSize, config.ClusterScaling.MaxSize, config.ClusterScaling.NodeFaultTolerance, capacity.NodeCount)
 
 	// If current utilization is less than max allowed, check to see if we can
@@ -99,14 +99,14 @@ func (c *nomadClient) EvaluateClusterCapacity(capacity *structs.ClusterAllocatio
 	if (clusterUtilization < capacity.MaxAllowedUtilization) || (capacity.ScalingMetric == ScalingMetricNone) {
 		capacity.ScalingDirection = ScalingDirectionIn
 
-		logging.Debug("api/nomad: Cluster Scaling (Metric: %v, Direction: %v, Capacity: %v, Utilization: %v, Max Allowed: %v)",
+		logging.Debug("client/nomad: Cluster Scaling (Metric: %v, Direction: %v, Capacity: %v, Utilization: %v, Max Allowed: %v)",
 			capacity.ScalingMetric, capacity.ScalingDirection, clusterCapacity, clusterUtilization, capacity.MaxAllowedUtilization)
 
 		if !c.CheckClusterScalingSafety(capacity, config, ScalingDirectionIn) {
-			logging.Debug("api/nomad: cluster scaling operation (scale-in) fails to pass the safety check")
+			logging.Debug("client/nomad: cluster scaling operation (scale-in) fails to pass the safety check")
 			return
 		}
-		logging.Debug("api/nomad: cluster scaling operation (scale-in) passes the safety check and will be permitted")
+		logging.Debug("client/nomad: cluster scaling operation (scale-in) passes the safety check and will be permitted")
 	}
 
 	// If current utilization is greater than max allowed, check to see if we can
@@ -114,15 +114,15 @@ func (c *nomadClient) EvaluateClusterCapacity(capacity *structs.ClusterAllocatio
 	if (clusterUtilization >= capacity.MaxAllowedUtilization) && (capacity.ScalingMetric != ScalingDirectionNone) {
 		capacity.ScalingDirection = ScalingDirectionOut
 
-		logging.Debug("api/nomad: Cluster Scaling (Metric: %v, Direction: %v, Capacity: %v, Utilization: %v, Max Allowed: %v)",
+		logging.Debug("client/nomad: Cluster Scaling (Metric: %v, Direction: %v, Capacity: %v, Utilization: %v, Max Allowed: %v)",
 			capacity.ScalingMetric, capacity.ScalingDirection, clusterCapacity, clusterUtilization, capacity.MaxAllowedUtilization)
 
 		if !c.CheckClusterScalingSafety(capacity, config, ScalingDirectionOut) {
-			logging.Debug("api/nomad: cluster scaling operation (scale-out) fails to pass the safety check")
+			logging.Debug("client/nomad: cluster scaling operation (scale-out) fails to pass the safety check")
 			return
 		}
 
-		logging.Debug("api/nomad: cluster scaling operation (scale-out) passes the safety check and will be permitted")
+		logging.Debug("client/nomad: cluster scaling operation (scale-out) passes the safety check and will be permitted")
 	}
 
 	return true, nil
@@ -142,7 +142,7 @@ func (c *nomadClient) CheckClusterScalingSafety(capacity *structs.ClusterAllocat
 	if scaleDirection == ScalingDirectionIn {
 		// Determine if removing a node would violate safety thresholds or declared minimums
 		if (capacity.NodeCount <= 1) || ((capacity.NodeCount - 1) < config.ClusterScaling.MinSize) {
-			logging.Debug("api/nomad: cluster scale-in operation would violate safety thresholds or declared minimums")
+			logging.Debug("client/nomad: cluster scale-in operation would violate safety thresholds or declared minimums")
 			return
 		}
 
@@ -154,17 +154,17 @@ func (c *nomadClient) CheckClusterScalingSafety(capacity *structs.ClusterAllocat
 		// we will not permit the scale-in operation.
 		newClusterUtilization := percent.PercentOf(clusterUsedCapacity, newMaxAllowedUtilization)
 
-		logging.Debug("api/nomad: max allowed cluster utilization after simulated node removal: %v (percent utilized: %v)",
+		logging.Debug("client/nomad: max allowed cluster utilization after simulated node removal: %v (percent utilized: %v)",
 			newMaxAllowedUtilization, newClusterUtilization)
 
 		// Evaluate utilization against new maximum allowed threshold and stop if a violation is present.
 		if (clusterUsedCapacity >= newMaxAllowedUtilization) || (newClusterUtilization >= scaleInCapacityThreshold) {
-			logging.Debug("api/nomad: cluster scale-in operation would violate or is too close to the maximum allowed cluster utilization threshold")
+			logging.Debug("client/nomad: cluster scale-in operation would violate or is too close to the maximum allowed cluster utilization threshold")
 			return
 		}
 	} else if scaleDirection == ScalingDirectionOut {
 		if (capacity.NodeCount + 1) > config.ClusterScaling.MaxSize {
-			logging.Debug("api/nomad: cluster scale-out operation would violate declared maximum threshold")
+			logging.Debug("client/nomad: cluster scale-out operation would violate declared maximum threshold")
 			return
 		}
 	}
@@ -172,7 +172,7 @@ func (c *nomadClient) CheckClusterScalingSafety(capacity *structs.ClusterAllocat
 	// Determine if performing a scaling operation would violate the scaling cooldown period.
 	if err := CheckClusterScalingTimeThreshold(config.ClusterScaling.CoolDown,
 		config.ClusterScaling.AutoscalingGroup, NewAWSAsgService(config.Region)); err != nil {
-		logging.Debug("api/nomad: %v", err)
+		logging.Debug("client/nomad: %v", err)
 		return
 	}
 
@@ -284,12 +284,12 @@ func (c *nomadClient) LeaderCheck() bool {
 
 	leader, err := c.nomad.Status().Leader()
 	if (err != nil) || (len(leader) == 0) {
-		logging.Error("api/nomad: failed to identify cluster leader")
+		logging.Error("client/nomad: failed to identify cluster leader")
 	}
 
 	self, err := c.nomad.Agent().Self()
 	if err != nil {
-		logging.Error("api/nomad: unable to retrieve local agent information")
+		logging.Error("client/nomad: unable to retrieve local agent information")
 	} else {
 
 		if helper.FindIP(leader) == self.Member.Addr {
@@ -402,7 +402,7 @@ func (c *nomadClient) LeastAllocatedNode(clusterInfo *structs.ClusterAllocation)
 	// to the nodes IP address so  the AWS instance-id can be infered.
 	resp, _, err := c.nomad.Nodes().Info(nodeID, &nomad.QueryOptions{})
 	if err != nil {
-		logging.Error("api/nomad: unable to determine nomad node IP address: %v", err)
+		logging.Error("client/nomad: unable to determine nomad node IP address: %v", err)
 	}
 	nodeIP = resp.Attributes["unique.network.ip-address"]
 
@@ -424,7 +424,7 @@ func (c *nomadClient) DrainNode(nodeID string) (err error) {
 	if (err != nil) || (resp.Drain != true) {
 		return err
 	}
-	logging.Info("api/nomad: node %v has been placed in drain mode\n", nodeID)
+	logging.Info("client/nomad: node %v has been placed in drain mode\n", nodeID)
 
 	// Setup a ticker to poll the node allocations and report when all existing
 	// allocations have been migrated to other worker nodes.
@@ -434,7 +434,7 @@ func (c *nomadClient) DrainNode(nodeID string) (err error) {
 	for {
 		select {
 		case <-timeout:
-			logging.Error("api/nomad: timeout %v reached while waiting for existing allocations to be migrated from node %v",
+			logging.Error("client/nomad: timeout %v reached while waiting for existing allocations to be migrated from node %v",
 				timeout, nodeID)
 			return nil
 		case <-ticker.C:
@@ -455,11 +455,11 @@ func (c *nomadClient) DrainNode(nodeID string) (err error) {
 			}
 
 			if activeAllocations == 0 {
-				logging.Info("api/nomad: node %v has no active allocations", nodeID)
+				logging.Info("client/nomad: node %v has no active allocations", nodeID)
 				return nil
 			}
 
-			logging.Info("api/nomad: node %v has %v active allocations, pausing and will re-poll allocations", nodeID, activeAllocations)
+			logging.Info("client/nomad: node %v has %v active allocations, pausing and will re-poll allocations", nodeID, activeAllocations)
 		}
 	}
 }
@@ -474,7 +474,7 @@ func (c *nomadClient) JobScale(scalingDoc *structs.JobScalingPolicy) {
 	jobResp, _, err := c.nomad.Jobs().Info(scalingDoc.JobName, &nomad.QueryOptions{})
 
 	if err != nil {
-		logging.Info("api/nomad: unable to determine job info of %v", scalingDoc.JobName)
+		logging.Info("client/nomad: unable to determine job info of %v", scalingDoc.JobName)
 		return
 	}
 
@@ -488,12 +488,12 @@ func (c *nomadClient) JobScale(scalingDoc *structs.JobScalingPolicy) {
 			for i, taskGroup := range jobResp.TaskGroups {
 				if group.Scaling.ScaleDirection == "Out" && *taskGroup.Count >= group.Scaling.Max ||
 					group.Scaling.ScaleDirection == "In" && *taskGroup.Count <= group.Scaling.Min {
-					logging.Debug("api/nomad: scale %v not permitted due to constraints on job \"%v\" and group \"%v\"",
+					logging.Debug("client/nomad: scale %v not permitted due to constraints on job \"%v\" and group \"%v\"",
 						group.Scaling.ScaleDirection, *jobResp.ID, group.GroupName)
 					return
 				}
 
-				logging.Info("api/nomad: scaling action (%v) will now be initiated against job \"%v\" and group \"%v\"",
+				logging.Info("client/nomad: scaling action (%v) will now be initiated against job \"%v\" and group \"%v\"",
 					group.Scaling.ScaleDirection, scalingDoc.JobName, group.GroupName)
 				// Depending on the scaling direction decrement/incrament the count;
 				// currently replicator only supports addition/subtraction of 1.
@@ -521,7 +521,7 @@ func (c *nomadClient) JobScale(scalingDoc *structs.JobScalingPolicy) {
 		return
 	}
 
-	logging.Info("api/nomad: scaling action successfully taken against job \"%v\"", *jobResp.ID)
+	logging.Info("client/nomad: scaling action successfully taken against job \"%v\"", *jobResp.ID)
 	return
 }
 
@@ -530,7 +530,7 @@ func (c *nomadClient) JobScale(scalingDoc *structs.JobScalingPolicy) {
 func (c *nomadClient) GetTaskGroupResources(jobName string, groupPolicy *structs.GroupScalingPolicy) {
 	jobs, _, err := c.nomad.Jobs().Info(jobName, &nomad.QueryOptions{})
 	if err != nil {
-		logging.Error("api/nomad: failed to retrieve job details for job %v: %v\n", jobName, err)
+		logging.Error("client/nomad: failed to retrieve job details for job %v: %v\n", jobName, err)
 	}
 
 	for _, group := range jobs.TaskGroups {
@@ -551,7 +551,7 @@ func (c *nomadClient) EvaluateJobScaling(jobs []*structs.JobScalingPolicy) {
 
 			allocs, _, err := c.nomad.Jobs().Allocations(policy.JobName, false, &nomad.QueryOptions{})
 			if err != nil {
-				logging.Error("api/nomad: failed to retrieve allocations for job %v: %v\n", policy.JobName, err)
+				logging.Error("client/nomad: failed to retrieve allocations for job %v: %v\n", policy.JobName, err)
 			}
 
 			c.GetJobAllocations(allocs, gsp)
@@ -592,7 +592,7 @@ func (c *nomadClient) GetJobAllocations(allocs []*nomad.AllocationListStub, gsp 
 func (c *nomadClient) GetAllocationStats(allocation *nomad.Allocation, scalingPolicy *structs.GroupScalingPolicy) {
 	stats, err := c.nomad.Allocations().Stats(allocation, &nomad.QueryOptions{})
 	if err != nil {
-		logging.Error("api/nomad: failed to retrieve allocation statistics from client %v: %v\n", allocation.NodeID, err)
+		logging.Error("client/nomad: failed to retrieve allocation statistics from client %v: %v\n", allocation.NodeID, err)
 		return
 	}
 
@@ -642,11 +642,11 @@ func MaxAllowedClusterUtilization(capacity *structs.ClusterAllocation, nodeFault
 		capacityTotal = capacityTotal - nodeAvgAlloc
 	}
 
-	logging.Debug("api/nomad: Cluster Capacity (CPU [MHz]: %v, Memory [MB]: %v)",
+	logging.Debug("client/nomad: Cluster Capacity (CPU [MHz]: %v, Memory [MB]: %v)",
 		capacity.TotalCapacity.CPUMHz, capacity.TotalCapacity.MemoryMB)
-	logging.Debug("api/nomad: Cluster Utilization (Scaling Metric: %v, CPU [MHz]: %v, Memory [MB]: %v)",
+	logging.Debug("client/nomad: Cluster Utilization (Scaling Metric: %v, CPU [MHz]: %v, Memory [MB]: %v)",
 		capacity.ScalingMetric, capacity.UsedCapacity.CPUMHz, capacity.UsedCapacity.MemoryMB)
-	logging.Debug("api/nomad: Scaling Metric (Algorithm): %v, Average Node Capacity: %v, Job Scaling Overhead: %v",
+	logging.Debug("client/nomad: Scaling Metric (Algorithm): %v, Average Node Capacity: %v, Job Scaling Overhead: %v",
 		internalScalingMetric, nodeAvgAlloc, allocTotal)
 
 	maxAllowedUtilization = ((capacityTotal - allocTotal) - (nodeAvgAlloc * nodeFaultTolerance))


### PR DESCRIPTION
This change implements protection against the divide by zero panic in #5. This panic can occur when the Nomad worker pool is in an unstable state resulting in Replicator detecting no healthy worker nodes. 

Once we evaluate the worker nodes and populate `NodeCount`, we will short-circuit the cluster scaling evaluation if `NodeCount` is 0. 

This change also modifies the logging prefixes to `client/nomad` and `client/aws` to reflect the renamed package.

Closes #5 