### PR TITLE
Increase Default Cluster Scaling Cooldown Period

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -46,7 +46,7 @@ func DefaultConfig() *structs.Config {
 		ClusterScaling: &structs.ClusterScaling{
 			MaxSize:            10,
 			MinSize:            5,
-			CoolDown:           300,
+			CoolDown:           600,
 			NodeFaultTolerance: 1,
 		},
 

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -26,7 +26,7 @@ package agent
 // 		ClusterScaling: &structs.ClusterScaling{
 // 			MaxSize:            10,
 // 			MinSize:            5,
-// 			CoolDown:           300,
+// 			CoolDown:           600,
 // 			NodeFaultTolerance: 1,
 // 		},
 //


### PR DESCRIPTION
This change increases the default cluster scaling cooldown period from `300` seconds to `600` seconds to accommodate new node bootstrapping.

Closes #54. 