### PR TITLE
Addition of CLI flags for all configuration parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,39 @@ Replicator supports a number of commands (CLI) which allow for the easy control 
 
 ### Command: agent
 
-The agent command is the main entry point into Replicator. A subset of the available replicator agent configuration can optionally be passed in via CLI arguments:
+The agent command is the main entry point into Replicator. A subset of the available replicator agent configuration can optionally be passed in via CLI arguments and the configuration parameters passed via CLI flags will always take precedent over parameters specified in configuration files.
 
-- -config=<path>: The path to either a single config file or a directory of config files to use for configuring the Replicator agent. Replicator processes configuration files in lexicographic order.
+- **-config=<path>** The path to either a single config file or a directory of config files to use for configuring the Replicator agent. Replicator processes configuration files in lexicographic order.
+
+- **-consul=<address:path>** This is the address of the Consul agent. By default, this is localhost:8500, which is the default bind and port for a local Consul agent. It is not recommended that you communicate directly with a Consul server, and instead communicate with the local Consul agent. There are many reasons for this, most importantly the Consul agent is able to multiplex connections to the Consul server and reduce the number of open HTTP connections. Additionally, it provides a "well-known" IP address for which clients can connect.
+
+- **-nomad=<address:path>** The address and port Replicator will use when making connections to the Nomad API. By default, this http://localhost:4646, which is the default bind and port for a local Nomad server.
+
+- **-log-level=<level>** Specify the verbosity level of Replicator's logs. The default is INFO.
+
+- **-scaling-interval=<num>** The time period in seconds between Replicator check runs. The default is 10.
+
+- **-aws-region=<region>** The AWS region in which the cluster is running. If no region is specified, Replicator attempts to dynamically determine the region.
+
+- **-cluster-scaling-enabled** Indicates whether the daemon should perform cluster scaling actions. If disabled, the actions that would have been taken will be reported in the logs but skipped.
+
+- **-cluster-max-size=<num>** Indicates the maximum number of worker nodes allowed in the cluster. The default is 10.
+
+- **-cluster-min-size=<num>** Indicates the minimum number of worker nodes allowed in the cluster. The default is 5.
+
+- **-cluster-scaling-cool-down=<num>** The number of seconds Replicator will wait between triggering cluster scaling actions. The default is 600.
+
+- **-cluster-node-fault-tolerance=<num>** The number of worker nodes the cluster can tolerate losing while still maintaining sufficient operation capacity. This is used by the scaling algorithm when calculating allowed capacity consumption. The default is 1.
+
+- **-cluster-autoscaling-group=<name>** The name of the AWS autoscaling group that contains the worker nodes. This should be a separate ASG from the one containing the server nodes.
+
+- **-job-scaling-enabled** Indicates whether the daemon should perform job scaling actions. If disabled, the actions that would have been taken will be reported in the logs but skipped.
+
+- **-consul-token=<token>** The Consul ACL token to use when communicating with an ACL protected Consul cluster.
+
+- **-consul-key-location=<key>** The Consul Key/Value Store location where Replicator will look for job scaling policies. By default, this is replicator/config/jobs.
+
+- **-statsd-address=<address:port>** Specifies the address of a StatsD server to forward metrics to and should include the port.
 
 ### Command: init
 
@@ -91,6 +121,9 @@ job_scaling {
 
   # The Consul ACL token to use when communicating with an ACL protected Consul cluster.
   consul_token        = "278F9E37-8322-4EDC-AFDC-748D116B3DCE"
+
+  # Indicates whether the daemon should perform scaling actions. If disabled, the actions that would have been taken will be reported in the logs but skipped.
+  enabled             = true
 }
 ```
 

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -15,51 +15,20 @@ import (
 	"github.com/elsevier-core-engineering/replicator/version"
 )
 
+// Command is the agent command strucutre used to track passed args as well as
+// the CLI meta.
 type Command struct {
 	command.Meta
-}
-
-// Help provides the help information for the agent command.
-func (c *Command) Help() string {
-	helpText := `
-  Usage: replicator agent [options]
-
-    Starts the Replicator agent and runs until an interrupt is received.
-    The Replicator agent's configuration primarily comes from the config
-    files used. If no config file is passed, a default config will be
-    used.
-
-  General Options:
-
-    -config=<path>
-      The path to either a single config file or a directory of config
-      files to use for configuring the Replicator agent. Replicator
-      processes configuration files in lexicographic order.
-`
-	return strings.TrimSpace(helpText)
-}
-
-// Synopsis is provides a brief summary of the agent command.
-func (c *Command) Synopsis() string {
-	return "Runs a Replicator agent"
+	args []string
 }
 
 // Run triggers a run of the replicator agent by setting up and parsing the
 // configuration and then initiating a new runner.
 func (c *Command) Run(args []string) int {
-	var config string
 
-	flags := c.Meta.FlagSet("agent", command.FlagSetClient)
-	flags.Usage = func() { c.UI.Output(c.Help()) }
-	flags.StringVar(&config, "config", "", "")
-
-	if err := flags.Parse(args); err != nil {
-		return 1
-	}
-
-	conf, err := c.setupConfig(args)
-	if err != nil {
-		c.UI.Error(fmt.Sprintf("%v", err))
+	c.args = args
+	conf := c.parseFlags()
+	if conf == nil {
 		return 1
 	}
 
@@ -82,7 +51,8 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
-	logging.Debug("command/agent: running version %v", version.Get())
+	logging.Info("command/agent: running version %v", version.Get())
+	logging.Info("command/agent: starting replicator agent...")
 	go runner.Start()
 
 	signalCh := make(chan os.Signal, 1)
@@ -105,7 +75,7 @@ func (c *Command) Run(args []string) int {
 				runner.Stop()
 
 				// Reload the configuration in order to make proper use of SIGHUP.
-				c, err := c.setupConfig(args)
+				c := c.parseFlags()
 				if err != nil {
 					return 1
 				}
@@ -122,34 +92,164 @@ func (c *Command) Run(args []string) int {
 	}
 }
 
-// setupConfig asseses the CLI arguments, or lack of, and then iterates through
-// the load order sementics for the configuration to return a configuration
-// object.
-func (c *Command) setupConfig(args []string) (*structs.Config, error) {
+func (c *Command) parseFlags() *structs.Config {
 
-	// If the length of the CLI args is greater than one then there is an error.
-	if len(args) > 1 {
-		return nil, fmt.Errorf("too many command line args")
+	var configPath string
+
+	// An empty new config is setup here to allow us to fill this with any passed
+	// cli flags for later merging.
+	cliConfig := &structs.Config{
+		ClusterScaling: &structs.ClusterScaling{},
+		JobScaling:     &structs.JobScaling{},
+		Telemetry:      &structs.Telemetry{},
 	}
 
-	// If no cli flags are passed then we just return a default configuration
-	// struct for use.
-	if len(args) == 0 {
-		return DefaultConfig(), nil
+	flags := c.Meta.FlagSet("agent", command.FlagSetClient)
+	flags.Usage = func() { c.UI.Error(c.Help()) }
+
+	flags.StringVar(&configPath, "config", "", "")
+
+	// Top level configuration flags
+	flags.StringVar(&cliConfig.Nomad, "nomad", "", "")
+	flags.StringVar(&cliConfig.Consul, "consul", "", "")
+	flags.StringVar(&cliConfig.LogLevel, "log-level", "", "")
+	flags.IntVar(&cliConfig.ScalingInterval, "scaling-interval", 0, "")
+	flags.StringVar(&cliConfig.Region, "aws-region", "", "")
+
+	// Cluster scaling configuration flags
+	flags.BoolVar(&cliConfig.ClusterScaling.Enabled, "cluster-scaling-enabled", false, "")
+	flags.IntVar(&cliConfig.ClusterScaling.MaxSize, "cluster-max-size", 0, "")
+	flags.IntVar(&cliConfig.ClusterScaling.MinSize, "cluster-mix-size", 0, "")
+	flags.Float64Var(&cliConfig.ClusterScaling.CoolDown, "cluster-scaling-cool-down", 0, "")
+	flags.IntVar(&cliConfig.ClusterScaling.NodeFaultTolerance, "cluster-node-fault-tolerance", 0, "")
+	flags.StringVar(&cliConfig.ClusterScaling.AutoscalingGroup, "cluster-autoscaling-group", "", "")
+
+	// Job scaling configuration flags
+	flags.BoolVar(&cliConfig.JobScaling.Enabled, "job-scaling-enabled", false, "")
+	flags.StringVar(&cliConfig.JobScaling.ConsulToken, "consul-token", "", "")
+	flags.StringVar(&cliConfig.JobScaling.ConsulKeyLocation, "consul-key-location", "", "")
+
+	// Telemetry configuration flags
+	flags.StringVar(&cliConfig.Telemetry.StatsdAddress, "statsd-address", "", "")
+
+	if err := flags.Parse(c.args); err != nil {
+		return nil
 	}
 
-	// If one CLI argument is passed this is split using the equals delimiter and
-	// the right hand side used as the configuration file/path to parse.
-	split := strings.Split(args[0], "=")
+	// Load the default configuration which will be the basis for merging with
+	// the supplied configuration file(s)
+	config := DefaultConfig()
 
-	switch p := split[0]; p {
-	case "-config":
-		c, err := FromPath(split[1])
+	if configPath != "" {
+		current, err := LoadConfig(configPath)
 		if err != nil {
-			return nil, err
+			c.UI.Error(fmt.Sprintf("Error loading configuration from %s: %s", configPath, err))
+			return nil
 		}
-		return c, nil
-	default:
-		return nil, fmt.Errorf("unable to correctly determine config location %v", split[1])
+
+		config = config.Merge(current)
 	}
+
+	config = config.Merge(cliConfig)
+	return config
+
+}
+
+// Help provides the help information for the agent command.
+func (c *Command) Help() string {
+	helpText := `
+  Usage: replicator agent [options]
+
+    Starts the Replicator agent and runs until an interrupt is received.
+    The Replicator agent's configuration primarily comes from the config
+    files used. If no config file is passed, a default config will be
+    used.
+
+  General Options:
+
+    -config=<path>
+      The path to either a single config file or a directory of config
+      files to use for configuring the Replicator agent. Replicator
+      processes configuration files in lexicographic order.
+
+    -consul=<address:port>
+      This is the address of the Consul agent. By default, this is
+      localhost:8500, which is the default bind and port for a local
+      Consul agent. It is not recommended that you communicate directly
+      with a Consul server, and instead communicate with the local
+      Consul agent. There are many reasons for this, most importantly
+      the Consul agent is able to multiplex connections to the Consul
+      server and reduce the number of open HTTP connections. Additionally,
+      it provides a "well-known" IP address for which clients can connect.
+
+    -nomad=<address:port>
+      The address and port Replicator will use when making connections
+      to the Nomad API. By default, this http://localhost:4646, which
+      is the default bind and port for a local Nomad server.
+
+    -log-level=<level>
+      Specify the verbosity level of Replicator's logs. The default is
+      INFO.
+
+    -scaling-interval=<num>
+      The time period in seconds between Replicator check runs. The
+      default is 10.
+
+    -aws-region=<region>
+      The AWS region in which the cluster is running. If no region is
+      specified, Replicator attempts to dynamically determine the region.
+
+    -cluster-scaling-enabled
+      Indicates whether the daemon should perform scaling actions. If
+      disabled, the actions that would have been taken will be reported
+      in the logs but skipped.
+
+    -cluster-max-size=<num>
+      Indicates the maximum number of worker nodes allowed in the cluster.
+      The default is 10.
+
+    -cluster-min-size=<num>
+      Indicates the minimum number of worker nodes allowed in the cluster.
+      The default is 5.
+
+    -cluster-scaling-cool-down=<num>
+      The number of seconds Replicator will wait between triggering
+      cluster scaling actions. The default is 600.
+
+    -cluster-node-fault-tolerance=<num>
+      The number of worker nodes the cluster can tolerate losing while
+      still maintaining sufficient operation capacity. This is used by
+      the scaling algorithm when calculating allowed capacity consumption.
+      The default is 1.
+
+    -cluster-autoscaling-group=<name>
+      The name of the AWS autoscaling group that contains the worker
+      nodes. This should be a separate ASG from the one containing
+      the server nodes.
+
+    -job-scaling-enabled
+      Indicates whether the daemon should perform scaling actions. If
+      disabled, the actions that would have been taken will be reported
+      in the logs but skipped.
+
+    -consul-token=<token>
+      The Consul ACL token to use when communicating with an ACL
+      protected Consul cluster.
+
+    -consul-key-location=<key>
+      The Consul Key/Value Store location where Replicator will look
+      for job scaling policies. By default, this is
+      replicator/config/jobs.
+
+    -statsd-address=<address:port>
+      Specifies the address of a statsd server to forward metrics
+      to and should include the port.
+
+`
+	return strings.TrimSpace(helpText)
+}
+
+// Synopsis is provides a brief summary of the agent command.
+func (c *Command) Synopsis() string {
+	return "Runs a Replicator agent"
 }

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -1,0 +1,244 @@
+package agent
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/elsevier-core-engineering/replicator/replicator/structs"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/hcl"
+	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/mitchellh/mapstructure"
+)
+
+// ParseConfigFile parses the given path as a config file.
+func ParseConfigFile(path string) (*structs.Config, error) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	config, err := ParseConfig(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+// ParseConfig parses the config from the given io.Reader.
+func ParseConfig(r io.Reader) (*structs.Config, error) {
+
+	// Copy the reader into an in-memory buffer first since HCL requires it.
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		return nil, err
+	}
+
+	// Parse the buffer
+	root, err := hcl.Parse(buf.String())
+	if err != nil {
+		return nil, fmt.Errorf("error parsing: %s", err)
+	}
+	buf.Reset()
+
+	// The top-level item should be a list.
+	list, ok := root.Node.(*ast.ObjectList)
+	if !ok {
+		return nil, fmt.Errorf("error parsing: root should be an object")
+	}
+
+	var config structs.Config
+	if err := parseConfig(&config, list); err != nil {
+		return nil, fmt.Errorf("error parsing 'config': %v", err)
+	}
+
+	return &config, nil
+}
+
+func parseConfig(result *structs.Config, list *ast.ObjectList) error {
+
+	// Check for invalid keys
+	valid := []string{
+		"nomad",
+		"consul",
+		"log_level",
+		"log_level",
+		"scaling_interval",
+		"aws_region",
+		"cluster_scaling",
+		"job_scaling",
+		"telemetry",
+	}
+	if err := checkHCLKeys(list, valid); err != nil {
+		return multierror.Prefix(err, "config:")
+	}
+
+	// Decode the full thing into a map[string]interface, removing these top
+	// levels before continuing to decode the remaining configuraiton.
+	var m map[string]interface{}
+	if err := hcl.DecodeObject(&m, list); err != nil {
+		return err
+	}
+
+	delete(m, "cluster_scaling")
+	delete(m, "job_scaling")
+	delete(m, "telemetry")
+
+	if err := mapstructure.WeakDecode(m, result); err != nil {
+		return err
+	}
+
+	// Parse the nested configuration portions which currently is ClusterScaling,
+	// JobScaling and Telemetry.
+	if o := list.Filter("cluster_scaling"); len(o.Items) > 0 {
+		if err := parseClusterScaling(&result.ClusterScaling, o); err != nil {
+			return multierror.Prefix(err, "cluster_scaling ->")
+		}
+	}
+
+	if o := list.Filter("job_scaling"); len(o.Items) > 0 {
+		if err := parseJobScaling(&result.JobScaling, o); err != nil {
+			return multierror.Prefix(err, "job_scaling ->")
+		}
+	}
+
+	if o := list.Filter("telemetry"); len(o.Items) > 0 {
+		if err := parseTelemetry(&result.Telemetry, o); err != nil {
+			return multierror.Prefix(err, "telemetry ->")
+		}
+	}
+
+	return nil
+}
+
+func parseClusterScaling(result **structs.ClusterScaling, list *ast.ObjectList) error {
+	list = list.Elem()
+	if len(list.Items) > 1 {
+		return fmt.Errorf("only one 'cluster_scaling' block allowed")
+	}
+
+	listVal := list.Items[0].Val
+
+	// Check for invalid keys
+	valid := []string{
+		"cluster_scaling_enabled",
+		"max_size",
+		"min_size",
+		"cool_down",
+		"node_fault_tolerance",
+		"autoscaling_group",
+	}
+	if err := checkHCLKeys(listVal, valid); err != nil {
+		return err
+	}
+
+	var m map[string]interface{}
+	if err := hcl.DecodeObject(&m, listVal); err != nil {
+		return err
+	}
+
+	var cluster structs.ClusterScaling
+	if err := mapstructure.WeakDecode(m, &cluster); err != nil {
+		return err
+	}
+	*result = &cluster
+	return nil
+}
+
+func parseJobScaling(result **structs.JobScaling, list *ast.ObjectList) error {
+	list = list.Elem()
+	if len(list.Items) > 1 {
+		return fmt.Errorf("only one 'job_scaling' block allowed")
+	}
+
+	listVal := list.Items[0].Val
+
+	// Check for invalid keys
+	valid := []string{
+		"job_scaling_enabled",
+		"consul_token",
+		"consul_key_location",
+	}
+	if err := checkHCLKeys(listVal, valid); err != nil {
+		return err
+	}
+
+	var m map[string]interface{}
+	if err := hcl.DecodeObject(&m, listVal); err != nil {
+		return err
+	}
+
+	var job structs.JobScaling
+	if err := mapstructure.WeakDecode(m, &job); err != nil {
+		return err
+	}
+	*result = &job
+	return nil
+}
+
+func parseTelemetry(result **structs.Telemetry, list *ast.ObjectList) error {
+	list = list.Elem()
+	if len(list.Items) > 1 {
+		return fmt.Errorf("only one 'Telemetry' block allowed")
+	}
+
+	listVal := list.Items[0].Val
+
+	// Check for invalid keys
+	valid := []string{
+		"statsd_address",
+	}
+	if err := checkHCLKeys(listVal, valid); err != nil {
+		return err
+	}
+
+	var m map[string]interface{}
+	if err := hcl.DecodeObject(&m, listVal); err != nil {
+		return err
+	}
+
+	var telemetry structs.Telemetry
+	if err := mapstructure.WeakDecode(m, &telemetry); err != nil {
+		return err
+	}
+	*result = &telemetry
+	return nil
+}
+
+func checkHCLKeys(node ast.Node, valid []string) error {
+	var list *ast.ObjectList
+	switch n := node.(type) {
+	case *ast.ObjectList:
+		list = n
+	case *ast.ObjectType:
+		list = n.List
+	default:
+		return fmt.Errorf("cannot check HCL keys of type %T", n)
+	}
+
+	validMap := make(map[string]struct{}, len(valid))
+	for _, v := range valid {
+		validMap[v] = struct{}{}
+	}
+
+	var result error
+	for _, item := range list.Items {
+		key := item.Keys[0].Token.Value().(string)
+		if _, ok := validMap[key]; !ok {
+			result = multierror.Append(result, fmt.Errorf(
+				"invalid key: %s", key))
+		}
+	}
+
+	return result
+}

--- a/command/init.go
+++ b/command/init.go
@@ -37,13 +37,14 @@ func (c *InitCommand) Synopsis() string {
 // Run triggers the init command to write the example.json file out to the
 // current directory.
 func (c *InitCommand) Run(args []string) int {
-	// Check for misuse
+
+	// The command should be used with 0 extra flags.
 	if len(args) != 0 {
 		c.UI.Error(c.Help())
 		return 1
 	}
 
-	// Check if the file already exists
+	// Check if the file already exists.
 	_, err := os.Stat(DefaultInitName)
 	if err != nil && !os.IsNotExist(err) {
 		c.UI.Error(fmt.Sprintf("Failed to stat '%s': %v", DefaultInitName, err))
@@ -54,7 +55,8 @@ func (c *InitCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Write out the example
+	// Write the example file to the relative local directory where Replicator
+	// was invoked from.
 	err = ioutil.WriteFile(DefaultInitName, []byte(defaultScalingDocument), 0660)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Failed to write '%s': %v", DefaultInitName, err))


### PR DESCRIPTION
The replicator agent now supports passing all configuration params
as CLI flags. The CLI flags can be used in conjunction with config
files, CLI flags taking precedent.

Coses #60 