### PR TITLE
Add support for `dev` CLI flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,37 +24,39 @@ Replicator supports a number of commands (CLI) which allow for the easy control 
 
 The agent command is the main entry point into Replicator. A subset of the available replicator agent configuration can optionally be passed in via CLI arguments and the configuration parameters passed via CLI flags will always take precedent over parameters specified in configuration files.
 
-- **-config=<path>** The path to either a single config file or a directory of config files to use for configuring the Replicator agent. Replicator processes configuration files in lexicographic order.
+- **-config=`<path>`** The path to either a single config file or a directory of config files to use for configuring the Replicator agent. Replicator processes configuration files in lexicographic order.
 
-- **-consul=<address:path>** This is the address of the Consul agent. By default, this is localhost:8500, which is the default bind and port for a local Consul agent. It is not recommended that you communicate directly with a Consul server, and instead communicate with the local Consul agent. There are many reasons for this, most importantly the Consul agent is able to multiplex connections to the Consul server and reduce the number of open HTTP connections. Additionally, it provides a "well-known" IP address for which clients can connect.
+- **-dev** Start the Replicator agent in development mode. This runs the Replicator agent with a configuration which is ideal for development or local testing.
 
-- **-nomad=<address:path>** The address and port Replicator will use when making connections to the Nomad API. By default, this http://localhost:4646, which is the default bind and port for a local Nomad server.
+- **-consul=`<address:path>`** This is the address of the Consul agent. By default, this is localhost:8500, which is the default bind and port for a local Consul agent. It is not recommended that you communicate directly with a Consul server, and instead communicate with the local Consul agent. There are many reasons for this, most importantly the Consul agent is able to multiplex connections to the Consul server and reduce the number of open HTTP connections. Additionally, it provides a "well-known" IP address for which clients can connect.
 
-- **-log-level=<level>** Specify the verbosity level of Replicator's logs. The default is INFO.
+- **-nomad=`<address:path>`** The address and port Replicator will use when making connections to the Nomad API. By default, this http://localhost:4646, which is the default bind and port for a local Nomad server.
 
-- **-scaling-interval=<num>** The time period in seconds between Replicator check runs. The default is 10.
+- **-log-level=`<level>`** Specify the verbosity level of Replicator's logs. The default is INFO.
 
-- **-aws-region=<region>** The AWS region in which the cluster is running. If no region is specified, Replicator attempts to dynamically determine the region.
+- **-scaling-interval=`<num>`** The time period in seconds between Replicator check runs. The default is 10.
+
+- **-aws-region=`<region>`** The AWS region in which the cluster is running. If no region is specified, Replicator attempts to dynamically determine the region.
 
 - **-cluster-scaling-enabled** Indicates whether the daemon should perform cluster scaling actions. If disabled, the actions that would have been taken will be reported in the logs but skipped.
 
-- **-cluster-max-size=<num>** Indicates the maximum number of worker nodes allowed in the cluster. The default is 10.
+- **-cluster-max-size=`<num>`** Indicates the maximum number of worker nodes allowed in the cluster. The default is 10.
 
-- **-cluster-min-size=<num>** Indicates the minimum number of worker nodes allowed in the cluster. The default is 5.
+- **-cluster-min-size=`<num>`** Indicates the minimum number of worker nodes allowed in the cluster. The default is 5.
 
-- **-cluster-scaling-cool-down=<num>** The number of seconds Replicator will wait between triggering cluster scaling actions. The default is 600.
+- **-cluster-scaling-cool-down=`<num>`** The number of seconds Replicator will wait between triggering cluster scaling actions. The default is 600.
 
-- **-cluster-node-fault-tolerance=<num>** The number of worker nodes the cluster can tolerate losing while still maintaining sufficient operation capacity. This is used by the scaling algorithm when calculating allowed capacity consumption. The default is 1.
+- **-cluster-node-fault-tolerance=`<num>`** The number of worker nodes the cluster can tolerate losing while still maintaining sufficient operation capacity. This is used by the scaling algorithm when calculating allowed capacity consumption. The default is 1.
 
-- **-cluster-autoscaling-group=<name>** The name of the AWS autoscaling group that contains the worker nodes. This should be a separate ASG from the one containing the server nodes.
+- **-cluster-autoscaling-group=`<name>`** The name of the AWS autoscaling group that contains the worker nodes. This should be a separate ASG from the one containing the server nodes.
 
 - **-job-scaling-enabled** Indicates whether the daemon should perform job scaling actions. If disabled, the actions that would have been taken will be reported in the logs but skipped.
 
-- **-consul-token=<token>** The Consul ACL token to use when communicating with an ACL protected Consul cluster.
+- **-consul-token=`<token>`** The Consul ACL token to use when communicating with an ACL protected Consul cluster.
 
-- **-consul-key-location=<key>** The Consul Key/Value Store location where Replicator will look for job scaling policies. By default, this is replicator/config/jobs.
+- **-consul-key-location=`<key>`** The Consul Key/Value Store location where Replicator will look for job scaling policies. By default, this is replicator/config/jobs.
 
-- **-statsd-address=<address:port>** Specifies the address of a StatsD server to forward metrics to and should include the port.
+- **-statsd-address=`<address:port>`** Specifies the address of a StatsD server to forward metrics to and should include the port.
 
 ### Command: init
 
@@ -71,20 +73,22 @@ Replicator uses the [HashiCorp Configuration Language](https://github.com/hashic
 You can specify a configuration file or a directory that contains configuration files using the `-config` flag. Replicator processes configuration files in lexicographic order.
 
 ```
-# This is the address of the Consul agent. By default, this is
-# localhost:8500, which is the default bind and port for a local Consul
-# agent. It is not recommended that you communicate directly with a Consul
-# server, and instead communicate with the local Consul agent. There are many
-# reasons for this, most importantly the Consul agent is able to multiplex
-# connections to the Consul server and reduce the number of open HTTP
-# connections. Additionally, it provides a "well-known" IP address for which
-# clients can connect.
+# This is the address of the Consul agent. By default, this is localhost:8500,
+# which is the default bind and port for a local Consul agent. It is not
+# recommended that you communicate directly with a Consul server, and instead
+# communicate with the local Consul agent. There are many reasons for this, most
+# importantly the Consul agent is able to multiplex connections to the Consul
+# server and reduce the number of open HTTP connections. Additionally, it
+# provides a "well-known" IP address for which clients can connect.
 consul     = "localhost:8500"
 
-# The address and port Replicator will use when making connections to the Nomad API. By default, this http://localhost:4646, which is the default bind and port for a local Nomad server.
+# The address and port Replicator will use when making connections to the Nomad
+# API. By default, this http://localhost:4646, which is the default bind and
+# port for a local Nomad server.
 nomad      = "http://localhost:4646"
 
-# The AWS region in which the cluster is running. If no region is specified, Replicator attempts to dynamically determine the region.
+# The AWS region in which the cluster is running. If no region is specified,
+# Replicator attempts to dynamically determine the region.
 aws_region = "us-east-1"
 
 # The log level the daemon should use.
@@ -95,7 +99,9 @@ scaling_interval = 10
 
 # This denotes the start of the configuration section for cluster autoscaling.
 cluster_scaling {
-  # Indicates whether the daemon should perform scaling actions. If disabled, the actions that would have been taken will be reported in the logs but skipped.
+  # Indicates whether the daemon should perform scaling actions. If disabled,
+  # the actions that would have been taken will be reported in the logs but
+  # skipped.
   enabled              = true
 
   # Indicates the maximum number of worker nodes allowed in the cluster.
@@ -107,23 +113,37 @@ cluster_scaling {
   # The number of seconds Replicator will wait between scaling actions.
   cool_down            = 120
 
-  # The number of worker nodes the cluster can tolerate losing while still maintaining sufficient operation capacity. This is used by the scaling algorithm when calculating allowed capacity consumption.
+  # The number of worker nodes the cluster can tolerate losing while still
+  # maintaining sufficient operation capacity. This is used by the scaling
+  # algorithm when calculating allowed capacity consumption.
   node_fault_tolerance = 1
 
-  # The name of the AWS autoscaling group that contains the worker nodes. This should be a separate ASG from the one containing the server nodes.
+  # The name of the AWS autoscaling group that contains the worker nodes. This
+  # should be a separate ASG from the one containing the server nodes.
   autoscaling_group    = "container-agent-dev"
 }
 
 # This denotes the start of the configuration section for job autoscaling.
 job_scaling {
-  # The Consul Key/Value Store location where Replicator will look for job scaling policies. By default, this is `replicator/config/jobs`.
+  # The Consul Key/Value Store location where Replicator will look for job
+  # scaling policies. By default, this is `replicator/config/jobs`.
   consul_key_location = "replicator/config/jobs"
 
-  # The Consul ACL token to use when communicating with an ACL protected Consul cluster.
+  # The Consul ACL token to use when communicating with an ACL protected Consul
+  # cluster.
   consul_token        = "278F9E37-8322-4EDC-AFDC-748D116B3DCE"
 
-  # Indicates whether the daemon should perform scaling actions. If disabled, the actions that would have been taken will be reported in the logs but skipped.
+  # Indicates whether the daemon should perform scaling actions. If disabled,
+  # the actions that would have been taken will be reported in the logs but
+  # skipped.
   enabled             = true
+}
+
+# This denotes the start of the configuration section for telemetry.
+telemetry {
+  # Specifies the address of a StatsD server to forward metrics to and should
+  # include the port.
+  statsd_address = "10.10.12.10:8125"
 }
 ```
 

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -95,6 +95,7 @@ func (c *Command) Run(args []string) int {
 func (c *Command) parseFlags() *structs.Config {
 
 	var configPath string
+	var dev bool
 
 	// An empty new config is setup here to allow us to fill this with any passed
 	// cli flags for later merging.
@@ -108,6 +109,7 @@ func (c *Command) parseFlags() *structs.Config {
 	flags.Usage = func() { c.UI.Error(c.Help()) }
 
 	flags.StringVar(&configPath, "config", "", "")
+	flags.BoolVar(&dev, "dev", false, "")
 
 	// Top level configuration flags
 	flags.StringVar(&cliConfig.Nomad, "nomad", "", "")
@@ -136,9 +138,15 @@ func (c *Command) parseFlags() *structs.Config {
 		return nil
 	}
 
-	// Load the default configuration which will be the basis for merging with
-	// the supplied configuration file(s)
-	config := DefaultConfig()
+	// Depending on the flags provided (if any) we load a default configuration
+	// which will be the basis for all merging.
+	var config *structs.Config
+
+	if dev {
+		config = DevConfig()
+	} else {
+		config = DefaultConfig()
+	}
 
 	if configPath != "" {
 		current, err := LoadConfig(configPath)

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -57,6 +57,46 @@ func DefaultConfig() *structs.Config {
 	}
 }
 
+// DevConfig returns a configuration struct with sane defaults for development
+// and testing purposes.
+func DevConfig() *structs.Config {
+
+	// Instantiate a new Consul client.
+	consulClient, err := client.NewConsulClient(LocalConsulAddress)
+	if err != nil {
+		logging.Error("command/agent: failed to obtain consul connection: %v", err)
+	}
+
+	// Instantiate a new Nomad client.
+	nomadClient, err := client.NewNomadClient(LocalNomadAddress)
+	if err != nil {
+		logging.Error("command/agent: failed to obtain nomad connection: %v", err)
+	}
+
+	return &structs.Config{
+		Consul:          LocalConsulAddress,
+		Nomad:           LocalNomadAddress,
+		LogLevel:        "DEBUG",
+		ScalingInterval: 10,
+
+		ClusterScaling: &structs.ClusterScaling{
+			Enabled:            false,
+			MaxSize:            1,
+			MinSize:            1,
+			CoolDown:           0,
+			NodeFaultTolerance: 0,
+		},
+
+		JobScaling: &structs.JobScaling{
+			ConsulKeyLocation: "replicator/config/jobs",
+		},
+
+		Telemetry:    &structs.Telemetry{},
+		ConsulClient: consulClient,
+		NomadClient:  nomadClient,
+	}
+}
+
 // LoadConfig loads the configuration at the given path whether the specified
 // path is an individual file or a directory of numerous configuration files.
 func LoadConfig(path string) (*structs.Config, error) {


### PR DESCRIPTION
The dev flag starts the Replicator agent in development mode. This
runs the Replicator agent with a configuration which is ideal for
development or local testing.

The configuration will still accept overrides from params passed
via CLI flags.

Closes #45