### PR TITLE
Fix incorrect cluster_scaling and job_scaling enabled config keys.

### DIFF
--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -139,7 +139,7 @@ func parseClusterScaling(result **structs.ClusterScaling, list *ast.ObjectList) 
 
 	// Check for invalid keys
 	valid := []string{
-		"cluster_scaling_enabled",
+		"enabled",
 		"max_size",
 		"min_size",
 		"cool_down",
@@ -173,7 +173,7 @@ func parseJobScaling(result **structs.JobScaling, list *ast.ObjectList) error {
 
 	// Check for invalid keys
 	valid := []string{
-		"job_scaling_enabled",
+		"enabled",
 		"consul_token",
 		"consul_key_location",
 	}


### PR DESCRIPTION
When a rework of the configuration parsing was done to accomodate
CLI falgs both the cluster_scaling and job_scaling enabled flags
we wrongly prefixed with their top level key. This meant that the
config files params allowed did not match the config struct
mapstructure designation and so was failing to work as expected.

This updates the config_parse to check for the correct keys thus
allowing enabled to be set on cluster and job scaling.

Closes #75 