### PR TITLE
AWS 'TerminateInstance' function now verifies instance terminated state.

### DIFF
--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -162,16 +162,6 @@ func (r *Runner) clusterScaling(done chan bool) {
 					logging.Error("core/runner: an error occurred while attempting "+
 						"to terminate instance %v: %v", instanceID, err)
 				}
-
-				// Pause after initiating termination of instance before retrying. This
-				// is a safety mechanism to deal with how slow the AWS autoscaling
-				// system is to respond to external facters such as an instance being
-				// terminated.
-				//
-				// TODO (e.westfall): Remove this after we place a ticker wait in
-				// the TerminateInstance() method to verify the instance has actually
-				// been terminated.
-				time.Sleep(45 * time.Second)
 			}
 		}
 


### PR DESCRIPTION
Previously the function would assume that a call to terminate the
instance which completed successfully was enough to ensure the
eventual instance termination. This change now implements a ticker
so that the function confirms that the instance ends in the state
of 'terminated' before returning successfully.

Closes #71 