### PR TITLE
Make use of telemetry configuration by sending key metrics.

### DIFF
--- a/client/consul.go
+++ b/client/consul.go
@@ -4,7 +4,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"strings"
+	"time"
 
+	metrics "github.com/armon/go-metrics"
 	"github.com/elsevier-core-engineering/replicator/replicator/structs"
 	consul "github.com/hashicorp/consul/api"
 )
@@ -36,6 +38,9 @@ func NewConsulClient(addr string) (structs.ConsulClient, error) {
 // policy document at a specified Consuk Key/Value Store location. Supports
 // the use of an ACL token if required by the Consul cluster.
 func (c *consulClient) GetJobScalingPolicies(config *structs.Config, nomadClient structs.NomadClient) ([]*structs.JobScalingPolicy, error) {
+
+	defer metrics.MeasureSince([]string{"job", "config_read"}, time.Now())
+
 	var entries []*structs.JobScalingPolicy
 
 	// Setup the QueryOptions to include the aclToken if this has been set, if not

--- a/client/nomad.go
+++ b/client/nomad.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"time"
 
+	metrics "github.com/armon/go-metrics"
 	"github.com/dariubs/percent"
 	"github.com/elsevier-core-engineering/replicator/helper"
 	"github.com/elsevier-core-engineering/replicator/logging"
@@ -498,10 +499,12 @@ func (c *nomadClient) JobScale(scalingDoc *structs.JobScalingPolicy) {
 				// Depending on the scaling direction decrement/incrament the count;
 				// currently replicator only supports addition/subtraction of 1.
 				if *taskGroup.Name == group.GroupName && group.Scaling.ScaleDirection == "Out" {
+					metrics.IncrCounter([]string{"job", scalingDoc.JobName, group.GroupName, "scale_out"}, 1)
 					*jobResp.TaskGroups[i].Count++
 				}
 
 				if *taskGroup.Name == group.GroupName && group.Scaling.ScaleDirection == "In" {
+					metrics.IncrCounter([]string{"job", scalingDoc.JobName, group.GroupName, "scale_in"}, 1)
 					*jobResp.TaskGroups[i].Count--
 				}
 			}

--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -3,6 +3,7 @@ package replicator
 import (
 	"time"
 
+	metrics "github.com/armon/go-metrics"
 	"github.com/elsevier-core-engineering/replicator/client"
 	"github.com/elsevier-core-engineering/replicator/logging"
 	"github.com/elsevier-core-engineering/replicator/replicator/structs"
@@ -146,6 +147,8 @@ func (r *Runner) clusterScaling(done chan bool) {
 					"the worker pool, incrementing node failure count to %v and "+
 					"terminating instance", newestNode, clusterCapacity.NodeFailureCount)
 
+				metrics.IncrCounter([]string{"cluster", "scale_out_failed"}, 1)
+
 				// Translate the IP address of the most recent instance to the EC2
 				// instance ID.
 				instanceID := client.TranslateIptoID(newestNode, r.config.Region)
@@ -198,6 +201,7 @@ func (r *Runner) clusterScaling(done chan bool) {
 		}
 	}
 	done <- true
+	metrics.IncrCounter([]string{"cluster", "scale_out_success"}, 1)
 	return
 }
 


### PR DESCRIPTION
This commit introduces initial metrics which will help debug and
understand Replicator performance. The telemetry configuration
setup has also been updated to allow future additional endpoints
as well as sending the USR1 signal to output metrics to the stderr
log.

Closes #67