### PR TITLE
Make cluster scaling retry threshold a user configurable option.

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -123,6 +123,7 @@ func (c *Command) parseFlags() *structs.Config {
 	flags.Float64Var(&cliConfig.ClusterScaling.CoolDown, "cluster-scaling-cool-down", 0, "")
 	flags.IntVar(&cliConfig.ClusterScaling.NodeFaultTolerance, "cluster-node-fault-tolerance", 0, "")
 	flags.StringVar(&cliConfig.ClusterScaling.AutoscalingGroup, "cluster-autoscaling-group", "", "")
+	flags.IntVar(&cliConfig.ClusterScaling.RetryThreshold, "cluster-retry-threshold", 0, "")
 
 	// Job scaling configuration flags
 	flags.BoolVar(&cliConfig.JobScaling.Enabled, "job-scaling-enabled", false, "")
@@ -273,6 +274,12 @@ func (c *Command) Help() string {
       still maintaining sufficient operation capacity. This is used by
       the scaling algorithm when calculating allowed capacity consumption.
       The default is 1.
+
+    -cluster-retry-threshold=<num>
+      Replicator fully verifies cluster scale-out by confirming the node
+      joins the cluster. If it does not join after a certain period the
+      actioned is marked as failed. This retry is the number of times
+      Replicator will attempt to scale the cluster with new instances.
 
     -cluster-scaling-cool-down=<num>
       The number of seconds Replicator will wait between triggering

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -45,6 +45,7 @@ func DefaultConfig() *structs.Config {
 			MinSize:            5,
 			CoolDown:           600,
 			NodeFaultTolerance: 1,
+			RetryThreshold:     2,
 		},
 
 		JobScaling: &structs.JobScaling{
@@ -86,6 +87,7 @@ func DevConfig() *structs.Config {
 			MinSize:            1,
 			CoolDown:           0,
 			NodeFaultTolerance: 0,
+			RetryThreshold:     1,
 		},
 
 		JobScaling: &structs.JobScaling{

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -145,6 +145,7 @@ func parseClusterScaling(result **structs.ClusterScaling, list *ast.ObjectList) 
 		"cool_down",
 		"node_fault_tolerance",
 		"autoscaling_group",
+		"retry_threshold",
 	}
 	if err := checkHCLKeys(listVal, valid); err != nil {
 		return err

--- a/replicator/structs/config.go
+++ b/replicator/structs/config.go
@@ -67,6 +67,10 @@ type ClusterScaling struct {
 
 	// AutoscalingGroup is the name of the ASG assigned to the Nomad worker nodes.
 	AutoscalingGroup string `mapstructure:"autoscaling_group"`
+
+	// RetryPeriod is the number of times Replicator will retry scale-out when
+	// new nodes do not join the worker pool and reach the join timeout.
+	RetryThreshold int `mapstructure:"retry_threshold"`
 }
 
 // JobScaling is the configuration struct for the Nomad job scaling activities.
@@ -190,6 +194,10 @@ func (c *ClusterScaling) Merge(b *ClusterScaling) *ClusterScaling {
 
 	if b.AutoscalingGroup != "" {
 		config.AutoscalingGroup = b.AutoscalingGroup
+	}
+
+	if b.RetryThreshold != 0 {
+		config.RetryThreshold = b.RetryThreshold
 	}
 
 	return &config


### PR DESCRIPTION
A new configuration parameter has been added to allow users to
configure the scaling retry threshold, thus determining the number
of attempts and failures replicator will attempt to scale the
cluster out before disabling scaling. The default has been set to
2.

Closes #77