### PR TITLE
Move Consul Configuration Parameters To Top-Level

### DIFF
--- a/client/consul.go
+++ b/client/consul.go
@@ -46,12 +46,12 @@ func (c *consulClient) GetJobScalingPolicies(config *structs.Config, nomadClient
 	// Setup the QueryOptions to include the aclToken if this has been set, if not
 	// procede with empty QueryOptions struct.
 	qop := &consul.QueryOptions{}
-	if config.JobScaling.ConsulToken != "" {
-		qop.Token = config.JobScaling.ConsulToken
+	if config.ConsulToken != "" {
+		qop.Token = config.ConsulToken
 	}
 
 	kvClient := c.consul.KV()
-	resp, _, err := kvClient.List(config.JobScaling.ConsulKeyLocation, qop)
+	resp, _, err := kvClient.List(config.ConsulKeyLocation, qop)
 	if err != nil {
 		return entries, err
 	}
@@ -67,7 +67,7 @@ func (c *consulClient) GetJobScalingPolicies(config *structs.Config, nomadClient
 		json.Unmarshal(uDec, s)
 
 		// Trim the Key and its trailing slash to find the job name.
-		s.JobName = strings.TrimPrefix(job.Key, config.JobScaling.ConsulKeyLocation+"/")
+		s.JobName = strings.TrimPrefix(job.Key, config.ConsulKeyLocation+"/")
 
 		// Check to see whether the job has running task groups before appending
 		// to the return.

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -110,13 +110,13 @@ func (c *Command) parseFlags() *structs.Config {
 	flags.BoolVar(&dev, "dev", false, "")
 
 	// Top level configuration flags
-	flags.StringVar(&cliConfig.Nomad, "nomad", "", "")
-	flags.StringVar(&cliConfig.Consul, "consul", "", "")
-	flags.StringVar(&cliConfig.ConsulToken, "consul-token", "", "")
-	flags.StringVar(&cliConfig.ConsulKeyLocation, "consul-key-location", "", "")
-	flags.StringVar(&cliConfig.LogLevel, "log-level", "", "")
-	flags.IntVar(&cliConfig.ScalingInterval, "scaling-interval", 0, "")
 	flags.StringVar(&cliConfig.Region, "aws-region", "", "")
+	flags.StringVar(&cliConfig.Consul, "consul", "", "")
+	flags.StringVar(&cliConfig.ConsulKeyLocation, "consul-key-location", "", "")
+	flags.StringVar(&cliConfig.ConsulToken, "consul-token", "", "")
+	flags.StringVar(&cliConfig.LogLevel, "log-level", "", "")
+	flags.StringVar(&cliConfig.Nomad, "nomad", "", "")
+	flags.IntVar(&cliConfig.ScalingInterval, "scaling-interval", 0, "")
 
 	// Cluster scaling configuration flags
 	flags.BoolVar(&cliConfig.ClusterScaling.Enabled, "cluster-scaling-enabled", false, "")
@@ -236,6 +236,15 @@ func (c *Command) Help() string {
       server and reduce the number of open HTTP connections. Additionally,
       it provides a "well-known" IP address for which clients can connect.
 
+    -consul-key-location=<key>
+      The Consul Key/Value Store location where Replicator will look
+      for persistent configuration and job scaling policies. By default,
+			this is replicator/config/jobs.
+
+    -consul-token=<token>
+      The Consul ACL token to use when communicating with an ACL
+      protected Consul cluster.
+
     -dev
       Start the Replicator agent in development mode. This runs the
       Replicator agent with a configuration which is ideal for development
@@ -291,15 +300,6 @@ func (c *Command) Help() string {
       in the logs but skipped.
 
   Job Scaling Options:
-
-    -consul-key-location=<key>
-      The Consul Key/Value Store location where Replicator will look
-      for job scaling policies. By default, this is
-      replicator/config/jobs.
-
-    -consul-token=<token>
-      The Consul ACL token to use when communicating with an ACL
-      protected Consul cluster.
 
     -job-scaling-enabled
       Indicates whether the daemon should perform scaling actions. If

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -239,7 +239,7 @@ func (c *Command) Help() string {
     -consul-key-location=<key>
       The Consul Key/Value Store location where Replicator will look
       for persistent configuration and job scaling policies. By default,
-			this is replicator/config/jobs.
+      this is replicator/config/jobs.
 
     -consul-token=<token>
       The Consul ACL token to use when communicating with an ACL

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -112,6 +112,8 @@ func (c *Command) parseFlags() *structs.Config {
 	// Top level configuration flags
 	flags.StringVar(&cliConfig.Nomad, "nomad", "", "")
 	flags.StringVar(&cliConfig.Consul, "consul", "", "")
+	flags.StringVar(&cliConfig.ConsulToken, "consul-token", "", "")
+	flags.StringVar(&cliConfig.ConsulKeyLocation, "consul-key-location", "", "")
 	flags.StringVar(&cliConfig.LogLevel, "log-level", "", "")
 	flags.IntVar(&cliConfig.ScalingInterval, "scaling-interval", 0, "")
 	flags.StringVar(&cliConfig.Region, "aws-region", "", "")
@@ -127,8 +129,6 @@ func (c *Command) parseFlags() *structs.Config {
 
 	// Job scaling configuration flags
 	flags.BoolVar(&cliConfig.JobScaling.Enabled, "job-scaling-enabled", false, "")
-	flags.StringVar(&cliConfig.JobScaling.ConsulToken, "consul-token", "", "")
-	flags.StringVar(&cliConfig.JobScaling.ConsulKeyLocation, "consul-key-location", "", "")
 
 	// Telemetry configuration flags
 	flags.StringVar(&cliConfig.Telemetry.StatsdAddress, "statsd-address", "", "")

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -35,10 +35,11 @@ func DefaultConfig() *structs.Config {
 	}
 
 	return &structs.Config{
-		Consul:          LocalConsulAddress,
-		Nomad:           LocalNomadAddress,
-		LogLevel:        "INFO",
-		ScalingInterval: 10,
+		Consul:            LocalConsulAddress,
+		ConsulKeyLocation: "replicator/config/jobs",
+		Nomad:             LocalNomadAddress,
+		LogLevel:          "INFO",
+		ScalingInterval:   10,
 
 		ClusterScaling: &structs.ClusterScaling{
 			MaxSize:            10,
@@ -48,9 +49,7 @@ func DefaultConfig() *structs.Config {
 			RetryThreshold:     2,
 		},
 
-		JobScaling: &structs.JobScaling{
-			ConsulKeyLocation: "replicator/config/jobs",
-		},
+		JobScaling: &structs.JobScaling{},
 
 		Telemetry:    &structs.Telemetry{},
 		Notification: &structs.Notification{},
@@ -76,10 +75,11 @@ func DevConfig() *structs.Config {
 	}
 
 	return &structs.Config{
-		Consul:          LocalConsulAddress,
-		Nomad:           LocalNomadAddress,
-		LogLevel:        "DEBUG",
-		ScalingInterval: 10,
+		Consul:            LocalConsulAddress,
+		ConsulKeyLocation: "replicator/config/jobs",
+		Nomad:             LocalNomadAddress,
+		LogLevel:          "DEBUG",
+		ScalingInterval:   10,
 
 		ClusterScaling: &structs.ClusterScaling{
 			Enabled:            false,
@@ -90,9 +90,7 @@ func DevConfig() *structs.Config {
 			RetryThreshold:     1,
 		},
 
-		JobScaling: &structs.JobScaling{
-			ConsulKeyLocation: "replicator/config/jobs",
-		},
+		JobScaling: &structs.JobScaling{},
 
 		Telemetry:    &structs.Telemetry{},
 		Notification: &structs.Notification{},

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -71,6 +71,8 @@ func parseConfig(result *structs.Config, list *ast.ObjectList) error {
 	valid := []string{
 		"nomad",
 		"consul",
+		"consul_key_location",
+		"consul_token",
 		"log_level",
 		"log_level",
 		"scaling_interval",
@@ -175,8 +177,6 @@ func parseJobScaling(result **structs.JobScaling, list *ast.ObjectList) error {
 	// Check for invalid keys
 	valid := []string{
 		"enabled",
-		"consul_token",
-		"consul_key_location",
 	}
 	if err := checkHCLKeys(listVal, valid); err != nil {
 		return err

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -11,11 +11,13 @@ import (
 func TestConfigParse_LoadConfigFile(t *testing.T) {
 
 	configFile := test.CreateTempfile([]byte(`
-    consul           = "consul.com:8500"
-    nomad            = "http://nomad.com:4646"
-    log_level        = "info"
-    scaling_interval = 1
-    aws_region       = "us-east-1"
+    consul                 = "consul.com:8500"
+		consul_key_location    = "wosniak/jobs"
+		consul_token           = "thisisafaketoken"
+    nomad                  = "http://nomad.com:4646"
+    log_level              = "info"
+    scaling_interval       = 1
+    aws_region             = "us-east-1"
 
     cluster_scaling {
       enabled              = true
@@ -28,8 +30,6 @@ func TestConfigParse_LoadConfigFile(t *testing.T) {
 
     job_scaling {
       enabled             = true
-      consul_key_location = "wosniak/jobs"
-      consul_token        = "thisisafaketoken"
     }
 
     telemetry {
@@ -51,11 +51,13 @@ func TestConfigParse_LoadConfigFile(t *testing.T) {
 	}
 
 	expected := &structs.Config{
-		Consul:          "consul.com:8500",
-		Nomad:           "http://nomad.com:4646",
-		LogLevel:        "info",
-		ScalingInterval: 1,
-		Region:          "us-east-1",
+		Consul:            "consul.com:8500",
+		ConsulKeyLocation: "wosniak/jobs",
+		ConsulToken:       "thisisafaketoken",
+		Nomad:             "http://nomad.com:4646",
+		LogLevel:          "info",
+		ScalingInterval:   1,
+		Region:            "us-east-1",
 
 		ClusterScaling: &structs.ClusterScaling{
 			Enabled:            true,
@@ -67,9 +69,7 @@ func TestConfigParse_LoadConfigFile(t *testing.T) {
 		},
 
 		JobScaling: &structs.JobScaling{
-			Enabled:           true,
-			ConsulKeyLocation: "wosniak/jobs",
-			ConsulToken:       "thisisafaketoken",
+			Enabled: true,
 		},
 
 		Telemetry: &structs.Telemetry{

--- a/replicator/structs/config.go
+++ b/replicator/structs/config.go
@@ -7,6 +7,14 @@ type Config struct {
 	// (may be an IP address or FQDN) with port.
 	Consul string `mapstructure:"consul"`
 
+	// ConsulKeyLocation is the Consul key location where scaling policies are
+	// defined.
+	ConsulKeyLocation string `mapstructure:"consul_key_location"`
+
+	// ConsulToken is the Consul ACL token used to access KeyValues from a
+	// secure Consul installation.
+	ConsulToken string `mapstructure:"consul_token"`
+
 	// Nomad is the location of the Nomad instance or cluster endpoint to query
 	// (may be an IP address or FQDN) with port.
 	Nomad string `mapstructure:"nomad"`
@@ -77,14 +85,6 @@ type ClusterScaling struct {
 type JobScaling struct {
 	// Enabled indicates whether job scaling actions are permitted.
 	Enabled bool `mapstructure:"enabled"`
-
-	// ConsulToken is the Consul ACL token used to access KeyValues from a
-	// secure Consul installation.
-	ConsulToken string `mapstructure:"consul_token"`
-
-	// ConsulKeyLocation is the Consul key location where scaling policies are
-	// defined.
-	ConsulKeyLocation string `mapstructure:"consul_key_location"`
 }
 
 // Telemetry is the struct that control the telemetry configuration. If a value
@@ -119,6 +119,14 @@ func (c *Config) Merge(b *Config) *Config {
 
 	if b.Consul != "" {
 		config.Consul = b.Consul
+	}
+
+	if b.ConsulToken != "" {
+		config.ConsulToken = b.ConsulToken
+	}
+
+	if b.ConsulKeyLocation != "" {
+		config.ConsulKeyLocation = b.ConsulKeyLocation
 	}
 
 	if b.LogLevel != "" {
@@ -209,14 +217,6 @@ func (j *JobScaling) Merge(b *JobScaling) *JobScaling {
 
 	if b.Enabled {
 		config.Enabled = b.Enabled
-	}
-
-	if b.ConsulToken != "" {
-		config.ConsulToken = b.ConsulToken
-	}
-
-	if b.ConsulKeyLocation != "" {
-		config.ConsulKeyLocation = b.ConsulKeyLocation
 	}
 
 	return &config


### PR DESCRIPTION
This change moves the `consul_key_location` and `consul_token` configuration parameters from the `job_scaling` section to top-level configuration parameters. 

Closes #92 and clears the way for #86, #83 and #32.