### PR TITLE
Support Persistent State Tracking

### DIFF
--- a/replicator/structs/consul.go
+++ b/replicator/structs/consul.go
@@ -75,4 +75,14 @@ type ConsulClient interface {
 	// policy document at a specified Consuk Key/Value Store location. Supports
 	// the use of an ACL token if required by the Consul cluster.
 	GetJobScalingPolicies(*Config, NomadClient) ([]*JobScalingPolicy, error)
+
+	// WriteState is responsible for persistently storing state tracking
+	// information in the Consul Key/Value Store.
+	WriteState(*Config, *ScalingState) error
+
+	// LoadState attempts to read state tracking information from the Consul
+	// Key/Value Store. If state tracking information is present, it will be
+	// preferred. If no persistent data is available, the method returns the
+	// state tracking object unmodified.
+	LoadState(*Config, *ScalingState) *ScalingState
 }

--- a/replicator/structs/nomad.go
+++ b/replicator/structs/nomad.go
@@ -77,15 +77,22 @@ type ScalingState struct {
 	// while attempting to perform scaling operations. When operating in failsafe
 	// mode, the daemon will decline to take scaling actions of any type.
 	// TODO (e.westfall): Implement failover mode functionality.
-	FailsafeMode bool
+	FailsafeMode bool `json:"failsafe_mode"`
+
+	// LastNodeFailure represents the last time a new worker node was launched
+	// and failed to successfully join the worker pool.
+	LastNodeFailure time.Time `json:"last_node_failure"`
 
 	// LastScalingEvent represents the last time the daemon successfully
 	// completed a cluster scaling action.
-	LastScalingEvent time.Time
+	LastScalingEvent time.Time `json:"last_scaling_event"`
+
+	// LastUpdated tracks the last time the state tracking data was updated.
+	LastUpdated time.Time `json:"last_updated"`
 
 	// NodeFailureCount tracks the number of worker nodes that have failed to
 	// successfully join the worker pool after a scale-out operation.
-	NodeFailureCount int
+	NodeFailureCount int `json:"node_failure_count"`
 }
 
 // ClusterCapacity is the central object used to track and evaluate cluster


### PR DESCRIPTION
This commit provides enhancements to the state
tracking mechanism including support for
persistent storage in a Consul Key/Value store.

When Replicator begins evaluating if a scaling
operation is required, it will first look for
persistent state tracking information and load
it into memory. If no persistent state tracking
information is found, or the attempt to retrieve
it fails, the in-memory data will be used.

This is critical to allowing Replicator to run as
a Nomad job or docker container while also
ensuring we can pick up where we left off. This
also clears the way for persistently locking the
daemon in `failsafe` mode after certain failure
modes are encountered (see #86 for more details).

Closes #83.