### PR TITLE
Replicator now runs leadership locking using Consul sessions +  KV

### DIFF
--- a/client/consul.go
+++ b/client/consul.go
@@ -195,3 +195,148 @@ func (c *consulClient) WriteState(config *structs.Config, state *structs.Scaling
 
 	return
 }
+
+// CreateSession creates a Consul session for use in the Leadership locking
+// process and will spawn off the renewing of the session in order to ensure
+// leadership can be maintained.
+func (c *consulClient) CreateSession(ttl int, stopCh chan struct{}) (id string, err error) {
+
+	entry := &consul.SessionEntry{
+		TTL:  fmt.Sprintf("%vs", ttl),
+		Name: "replicator_leader_lock",
+	}
+
+	// Create the key session.
+	logging.Debug("client/consul: obtaining Consul session with %vs TTL", ttl)
+	resp, _, err := c.consul.Session().Create(entry, nil)
+	if err != nil {
+		return "", err
+	}
+
+	// Spawn off to continue renewing our session.
+	c.renewSession(entry.TTL, resp, stopCh)
+
+	return resp, nil
+}
+
+// AcquireLeadership attempts to acquire a Consul leadersip lock using the
+// provided session. If the lock is already taken this will return false in
+// a show that there is already a leader.
+func (c *consulClient) AcquireLeadership(key, session string) (aquired bool) {
+
+	// Attempt to inspect the leadership key if it is available and present.
+	k, _, err := c.consul.KV().Get(key, nil)
+
+	if err != nil {
+		logging.Error("client/consul: unable to read the leader key at %s", key)
+		return false
+	}
+
+	// On a fresh cluster the KV might not exist yet, so we need to check for nil
+	// return. If the leadership lock is tied to our session then we can exit and
+	// confirm we are running as the replicator leader without having to make on
+	// further calls.
+	if k != nil && k.Session == session {
+		return true
+	}
+
+	kp := &consul.KVPair{
+		Key:     key,
+		Session: session,
+	}
+
+	logging.Debug("client/consul: attempting to aquire leadership lock at %s", key)
+	resp, _, err := c.consul.KV().Acquire(kp, nil)
+
+	if err != nil {
+		logging.Error("client/consul: issue requesting leadership lock: %v", err)
+		return false
+	}
+
+	// We have successfully obtained the leadership and can now be considered as
+	// the replicator leader.
+	if resp {
+		logging.Info("client/consul: leadership lock successfully obtained at %s", key)
+		metrics.IncrCounter([]string{"cluster", "leadership", "election"}, 1)
+		return true
+	}
+
+	return false
+}
+
+// ResignLeadership attempts to remove the leadership lock upon shutdown of the
+// replicator daemon. If this is unsuccessful there is not too much we can do
+// therefore there is no return.
+func (c *consulClient) ResignLeadership(key, session string) {
+
+	kp := &consul.KVPair{
+		Key:     key,
+		Session: session,
+	}
+
+	resp, _, err := c.consul.KV().Release(kp, nil)
+	if err != nil {
+		logging.Error("client/consul: unable to successfully release leadership lock: %v", err)
+		return
+	}
+
+	// If we get a successful response we should log it.
+	if resp {
+		logging.Info("client/consul: the leadership lock has now been released")
+	}
+
+	return
+}
+
+// renewSession is used for renewing a Consul session and accepts a channel
+// within which a signal can be sent which will stop the renawl process and
+// attempt to clean up the session.
+func (c *consulClient) renewSession(ttl string, session string, renewChan chan struct{}) {
+
+	sessionDestroyAttempts := 0
+	maxSessionDestroyAttempts := 5
+
+	parsedTTL, err := time.ParseDuration(ttl)
+	if err != nil {
+		return
+	}
+
+	go func() {
+		for {
+			select {
+			case <-time.After(parsedTTL / 2):
+				entry, _, err := c.consul.Session().Renew(session, nil)
+				if err != nil {
+					continue
+				}
+				if entry == nil {
+					return
+				}
+
+				// Consul may return a TTL value higher than the one specified during
+				// session creation. This indicates the server is under high load and
+				// is requesting clients renew less often. If this happens we need to
+				// ensure we track the new TTL.
+				parsedTTL, _ = time.ParseDuration(entry.TTL)
+				logging.Debug("client/consul: the Consul session %s has been renewed", session)
+
+			case <-renewChan:
+				_, err := c.consul.Session().Destroy(session, nil)
+				if err == nil {
+					logging.Info("client/consul: the Consul session %s has been released", session)
+					return
+				}
+
+				if sessionDestroyAttempts >= maxSessionDestroyAttempts {
+					logging.Error("client/consul: unable to successfully destroy the Consul session %s", session)
+					return
+				}
+
+				// We can't destroy the session so we will wait and attempt again until
+				// we hit the threshold.
+				sessionDestroyAttempts++
+				time.Sleep(parsedTTL)
+			}
+		}
+	}()
+}

--- a/client/nomad.go
+++ b/client/nomad.go
@@ -272,28 +272,6 @@ func CalculateUsage(clusterInfo *structs.ClusterCapacity) {
 	}
 }
 
-// LeaderCheck determines if the node running the daemon is the gossip pool leader.
-func (c *nomadClient) LeaderCheck() bool {
-	haveLeadership := false
-
-	leader, err := c.nomad.Status().Leader()
-	if (err != nil) || (len(leader) == 0) {
-		logging.Error("client/nomad: failed to identify cluster leader")
-	}
-
-	self, err := c.nomad.Agent().Self()
-	if err != nil {
-		logging.Error("client/nomad: unable to retrieve local agent information")
-	} else {
-
-		if helper.FindIP(leader) == self.Member.Addr {
-			haveLeadership = true
-		}
-	}
-
-	return haveLeadership
-}
-
 // TaskAllocation determines the total allocation requirements of a single instance (count=1)
 // of all running jobs across the cluster. This is used to practively ensure the cluster
 // has sufficient available capacity to scale each task by +1 if an increase in capacity

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -65,10 +65,12 @@ func (c *Command) Run(args []string) int {
 		case s := <-signalCh:
 			switch s {
 			case syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT:
+				logging.Info("command/agent: caught signal %v", s)
 				runner.Stop()
-				return 0
+				return 1
 
 			case syscall.SIGHUP:
+				logging.Info("command/agent: caught signal %v", s)
 				runner.Stop()
 
 				// Reload the configuration in order to make proper use of SIGHUP.

--- a/replicator/leader.go
+++ b/replicator/leader.go
@@ -1,0 +1,89 @@
+package replicator
+
+import (
+	"github.com/elsevier-core-engineering/replicator/logging"
+	"github.com/elsevier-core-engineering/replicator/replicator/structs"
+)
+
+// LeaderCandidate runs the leader election.
+type LeaderCandidate struct {
+	consulClient structs.ConsulClient
+
+	leader  bool
+	key     string
+	session string
+	ttl     int
+
+	renewChan chan struct{}
+}
+
+// newLeaderCandidate creates a new LeaderCandidate.
+func newLeaderCandidate(consulClient structs.ConsulClient, key string, ttl int) *LeaderCandidate {
+	return &LeaderCandidate{
+		consulClient: consulClient,
+		key:          key,
+		leader:       false,
+		ttl:          ttl,
+	}
+}
+
+// isLeader returns true if the candidate is currently a leader.
+func (l *LeaderCandidate) isLeader() bool {
+	return l.leader
+}
+
+// leaderElection is the main entry in to the Replicator leadership locking
+// process and will create a Consul session for use in obtainibg the leader
+// lock.
+func (l *LeaderCandidate) leaderElection() (isLeader bool) {
+
+	// Always set ourself to assume we are not the leader, so that even the
+	// current leader must confirm its status and not blindly assume leadership.
+	l.leader = false
+
+	// Create our session and start the renew process if the candidate does not
+	// currently have one.
+	if l.session == "" {
+
+		l.renewChan = make(chan struct{})
+
+		id, err := l.consulClient.CreateSession(l.ttl, l.renewChan)
+		if err != nil {
+			logging.Error("core/leader: unable to obtain Consul session: %v", err)
+			return
+		}
+
+		// Store our sessionID.
+		l.session = id
+	}
+
+	// Attempt to acquire the leadership lock.
+	if isLeader = l.consulClient.AcquireLeadership(l.key, l.session); isLeader {
+		logging.Debug("core/leader: currently running as Replicator leader")
+		l.leader = true
+		return true
+	}
+
+	return
+}
+
+// endCampaign attempts to gracefully remove sessions and locks assosiated with
+// the replicator leadership locking, allowing other daemons to pick up the lock
+// without having to wait for the TTL to expire.
+func (l *LeaderCandidate) endCampaign() {
+	logging.Info("core/runner: gracefully cleaning up Consul sessions and locks")
+
+	l.releaseSession()
+
+	if l.leader {
+		l.consulClient.ResignLeadership(l.key, l.session)
+	}
+}
+
+// releaseSession closes the renewChan therefore telling the renewSession
+// process to try and destroy the session.
+func (l *LeaderCandidate) releaseSession() {
+	if l.renewChan != nil {
+		close(l.renewChan)
+	}
+}

--- a/replicator/structs/consul.go
+++ b/replicator/structs/consul.go
@@ -85,4 +85,10 @@ type ConsulClient interface {
 	// preferred. If no persistent data is available, the method returns the
 	// state tracking object unmodified.
 	LoadState(*Config, *ScalingState) *ScalingState
+
+	CreateSession(int, chan struct{}) (string, error)
+
+	AcquireLeadership(string, string) bool
+
+	ResignLeadership(string, string)
 }

--- a/replicator/structs/nomad.go
+++ b/replicator/structs/nomad.go
@@ -44,10 +44,6 @@ type NomadClient interface {
 	// thresholds set.
 	JobScale(*JobScalingPolicy)
 
-	// LeaderCheck determines if the node running replicator is the gossip pool
-	// leader.
-	LeaderCheck() bool
-
 	// LeaseAllocatedNode determines the worker node consuming the least amount of
 	// the cluster's mosted-utilized resource.
 	LeastAllocatedNode(*ClusterCapacity) (string, string)


### PR DESCRIPTION
This requirement helps move Replicator towards being able to run
as a Nomad job. Each replicator instance will obtain a Consul
session and then attempt to gain a lock on a Consul KV. The session
is continually renewed in the background and non-leadership locking
instances will continue to attempt to gain the lock.

If a leader instance is shutdown, it will attempt to release its
session and lock allowing other instances to obtain the lock quicker
than waiting for the TTL to expire.

Telemetry has been added as a counter for leadership aquisition
events.

Closes #32