### PR TITLE
Correctly initialise clients after config parsing.

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -8,8 +8,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/elsevier-core-engineering/replicator/client"
-	"github.com/elsevier-core-engineering/replicator/logging"
 	"github.com/elsevier-core-engineering/replicator/replicator/structs"
 )
 
@@ -21,18 +19,6 @@ const (
 
 // DefaultConfig returns a default configuration struct with sane defaults.
 func DefaultConfig() *structs.Config {
-
-	// Instantiate a new Consul client.
-	consulClient, err := client.NewConsulClient(LocalConsulAddress)
-	if err != nil {
-		logging.Error("command/agent: failed to obtain consul connection: %v", err)
-	}
-
-	// Instantiate a new Nomad client.
-	nomadClient, err := client.NewNomadClient(LocalNomadAddress)
-	if err != nil {
-		logging.Error("command/agent: failed to obtain nomad connection: %v", err)
-	}
 
 	return &structs.Config{
 		Consul:            LocalConsulAddress,
@@ -53,26 +39,12 @@ func DefaultConfig() *structs.Config {
 
 		Telemetry:    &structs.Telemetry{},
 		Notification: &structs.Notification{},
-		ConsulClient: consulClient,
-		NomadClient:  nomadClient,
 	}
 }
 
 // DevConfig returns a configuration struct with sane defaults for development
 // and testing purposes.
 func DevConfig() *structs.Config {
-
-	// Instantiate a new Consul client.
-	consulClient, err := client.NewConsulClient(LocalConsulAddress)
-	if err != nil {
-		logging.Error("command/agent: failed to obtain consul connection: %v", err)
-	}
-
-	// Instantiate a new Nomad client.
-	nomadClient, err := client.NewNomadClient(LocalNomadAddress)
-	if err != nil {
-		logging.Error("command/agent: failed to obtain nomad connection: %v", err)
-	}
 
 	return &structs.Config{
 		Consul:            LocalConsulAddress,
@@ -94,8 +66,6 @@ func DevConfig() *structs.Config {
 
 		Telemetry:    &structs.Telemetry{},
 		Notification: &structs.Notification{},
-		ConsulClient: consulClient,
-		NomadClient:  nomadClient,
 	}
 }
 


### PR DESCRIPTION
The Nomad and Consul clients are now stuffed into the config
struct after config parsing has occured meaning replicator
correctly uses the user specified endpoints. The Consul token is
also evaluated at this stage allowing us to remove all of the
Read/WriteOptions{} setups in client/consul.go.

Along with this the telemetry and logging gets setup in a new
function which allows replicator to correctly reload config
changes and apply them.

Closes #100