### PR TITLE
Introduce Distributed Failsafe Mode

### DIFF
--- a/client/consul.go
+++ b/client/consul.go
@@ -86,7 +86,7 @@ func (c *consulClient) GetJobScalingPolicies(config *structs.Config, nomadClient
 // Key/Value Store. If state tracking information is present, it will be
 // deserialized and returned as a state tracking object. If no persistent
 // data is available, the method returns the state tracking object unmodified.
-func (c *consulClient) LoadState(config *structs.Config, state *structs.ScalingState) *structs.ScalingState {
+func (c *consulClient) LoadState(config *structs.Config, state *structs.State) *structs.State {
 	// TODO (e.westfall): Convert to using base path from configuration, see
 	// GH-94 for further details.
 	stateKey := "replicator/config/state"
@@ -95,7 +95,7 @@ func (c *consulClient) LoadState(config *structs.Config, state *structs.ScalingS
 		"information from Consul at location %v", stateKey)
 
 	// Create new scaling state struct to hold state data retrieved from Consul.
-	updatedState := &structs.ScalingState{}
+	updatedState := &structs.State{}
 
 	// Instantiate new Consul Key/Value client.
 	kv := c.consul.KV()
@@ -138,7 +138,7 @@ func (c *consulClient) LoadState(config *structs.Config, state *structs.ScalingS
 
 // WriteState is responsible for persistently storing state tracking
 // information in the Consul Key/Value Store.
-func (c *consulClient) WriteState(config *structs.Config, state *structs.ScalingState) (err error) {
+func (c *consulClient) WriteState(config *structs.Config, state *structs.State) (err error) {
 	// TODO (e.westfall): Convert to using base path from configuration, see
 	// GH-94 for further details.
 	stateKey := "replicator/config/state"

--- a/command/base/config.go
+++ b/command/base/config.go
@@ -1,4 +1,4 @@
-package agent
+package base
 
 import (
 	"fmt"
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/elsevier-core-engineering/replicator/client"
 	"github.com/elsevier-core-engineering/replicator/replicator/structs"
 )
 
@@ -67,6 +68,27 @@ func DevConfig() *structs.Config {
 		Telemetry:    &structs.Telemetry{},
 		Notification: &structs.Notification{},
 	}
+}
+
+// InitializeClients completes the setup process for the Nomad and Consul
+// clients. Must be called after configuration merging is complete.
+func InitializeClients(config *structs.Config) (err error) {
+	// Setup the Nomad Client
+	nClient, err := client.NewNomadClient(config.Nomad)
+	if err != nil {
+		return
+	}
+
+	// Setup the Consul Client
+	cClient, err := client.NewConsulClient(config.Consul, config.ConsulToken)
+	if err != nil {
+		return
+	}
+
+	config.ConsulClient = cClient
+	config.NomadClient = nClient
+
+	return
 }
 
 // LoadConfig loads the configuration at the given path whether the specified

--- a/command/base/config_parse.go
+++ b/command/base/config_parse.go
@@ -1,4 +1,4 @@
-package agent
+package base
 
 import (
 	"bytes"

--- a/command/base/config_parse_test.go
+++ b/command/base/config_parse_test.go
@@ -1,4 +1,4 @@
-package agent
+package base
 
 import (
 	"reflect"

--- a/command/base/config_test.go
+++ b/command/base/config_test.go
@@ -1,4 +1,4 @@
-package agent
+package base
 
 import (
 	"io/ioutil"

--- a/command/failsafe.go
+++ b/command/failsafe.go
@@ -1,0 +1,239 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/elsevier-core-engineering/replicator/command/base"
+	core "github.com/elsevier-core-engineering/replicator/replicator"
+	"github.com/elsevier-core-engineering/replicator/replicator/structs"
+)
+
+// FailsafeCommand is a command implementation that allows operators to
+// place the daemon in or take the daemon out of failsafe mode.
+type FailsafeCommand struct {
+	Meta
+	args []string
+}
+
+// Help provides the help information for the failsafe command.
+func (c *FailsafeCommand) Help() string {
+	helpText := `
+Usage: replicator failsafe [options]
+
+  Allows an operator to administratively control the failsafe behavior
+  of Replicator. When Replicator enters failsafe mode, all running
+  copies of Replicator will prohibit any scaling operations.
+
+  Failsafe mode is intended to stabilize a cluster that has experienced
+  consecutive critical failures while attempting to perform scaling
+  operations.
+
+  To exit failsafe mode, an operator must explicitly remove the failsafe
+  lock after identifying the root cause of the failures.
+
+  General Options:
+
+    -config=<path>
+      The path to either a single config file or a directory of config
+      files to use when configuring the Replicator agent. Replicator
+      processes configuration files in lexicographic order.
+
+    -consul=<address:port>
+      This is the address of the Consul agent. By default, this is
+      localhost:8500, which is the default bind and port for a local
+      Consul agent. It is not recommended that you communicate directly
+      with a Consul server, and instead communicate with the local
+      Consul agent. There are many reasons for this, most importantly
+      the Consul agent is able to multiplex connections to the Consul
+      server and reduce the number of open HTTP connections. Additionally,
+      it provides a "well-known" IP address for which clients can connect.
+
+    -consul-key-location=<key>
+      The Consul Key/Value Store location that Replicator will use
+      for persistent configuration, state tracking and job scaling policies.
+			By default, this is replicator/config.
+
+    -consul-token=<token>
+      The Consul ACL token to use when communicating with an ACL
+      protected Consul cluster.
+
+  Failsafe Mode Options:
+
+    -disable
+      Disable the global failsafe lock. All copies of Replicator wil
+      return to normal operations.
+
+    -enable
+      Enable the global failsafe lock. All copies of Replicator will
+      be prohibited from taking any scaling actions.
+
+    -force
+      Suppress confirmation prompts when enabling or disabling the
+      global failsafe lock.
+`
+	return strings.TrimSpace(helpText)
+}
+
+// Synopsis is provides a brief summary of the failsafe command.
+func (c *FailsafeCommand) Synopsis() string {
+	return "Provide an administrative interface to control failsafe mode."
+}
+
+// Run triggers the failsafe command to update the distributed state tracking
+// data and manipulate the failsafe lock.
+func (c *FailsafeCommand) Run(args []string) int {
+	// Initialize an new empty state tracking object.
+	state := &structs.State{}
+
+	// The operator must specify at least one operation.
+	if len(args) == 0 {
+		c.UI.Error(c.Help())
+		return 1
+	}
+
+	// Parse flags and generate a resulting configuration.
+	c.args = args
+	conf := c.parseFlags()
+	if conf == nil {
+		return 1
+	}
+
+	// Setup the Consul client.
+	if err := base.InitializeClients(conf.Config); err != nil {
+		c.UI.Error(fmt.Sprintf("An error occurred while attempting to initialize "+
+			"the Consul client: %v", err))
+		return 1
+	}
+
+	// Grab the initialized consul client from the returned configuration object.
+	consul := conf.Config.ConsulClient
+
+	// Check that we were sent either enable or disable, but not both.
+	if (conf.Enable && conf.Disable) || (!conf.Enable && !conf.Disable) {
+		c.UI.Error(c.Help())
+		return 1
+	}
+
+	// Attempt to load state tracking data from Consul.
+	state = consul.LoadState(conf.Config, state)
+
+	// If failsafe mode is already in the desired state, report and take no
+	// action.
+	if state.FailsafeMode && conf.Enable || !state.FailsafeMode && conf.Disable {
+		c.UI.Warn(fmt.Sprintf("Failsafe mode is already in desired state \"%vd\""+
+			", no action required.", conf.Verb))
+		return 0
+	}
+
+	// If the user has not disabled confirmation prompts, ask for confirmation.
+	if !conf.Force {
+		keyLocation := conf.Config.ConsulKeyLocation + "/" + "state"
+
+		question := fmt.Sprintf("Are you sure you want to %s the global failsafe "+
+			"lock stored at %q?\n", conf.Verb, keyLocation)
+
+		// If we're enabling failsafe mode, give the user a clear warning about
+		// the implications.
+		if conf.Enable {
+			question = fmt.Sprintf("%vNo scaling operations will be permitted "+
+				"from any running copies of Replicator.\n", question)
+		}
+
+		// Ask for confirmation and parse the response.
+		answer, err := c.UI.Ask(fmt.Sprintf("%vConfirm [y/N]: ", question))
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Failed to parse answer: %v", err))
+			return 1
+		}
+
+		// Validate the confirmation response.
+		if answer == "" || strings.ToLower(answer)[0] == 'n' {
+			c.UI.Output(fmt.Sprintf("Cancelling, will not %v failsafe mode.",
+				conf.Verb))
+			return 0
+		} else if strings.ToLower(answer)[0] == 'y' && len(answer) > 1 {
+			c.UI.Output("For confirmation, an exact 'y' is required.")
+			return 0
+		} else if answer != "y" {
+			c.UI.Output("No confirmation detected. For confirmation, an exact 'y' " +
+				"is required.")
+			return 1
+		}
+	}
+
+	// Indicate that failsafe mode was administratively updated.
+	state.FailsafeModeAdmin = true
+
+	// Set desired failsafe mode.
+	if err := core.SetFailsafeMode(state, conf.Config, conf.Enable); err != nil {
+		c.UI.Error(fmt.Sprintf("An error occurred while attempting to %v "+
+			"failsafe mode: %v", conf.Verb, err))
+		return 1
+	}
+
+	c.UI.Info(fmt.Sprintf("Successfully %vd failsafe mode.", conf.Verb))
+
+	return 0
+}
+
+func (c *FailsafeCommand) parseFlags() *structs.FailsafeMode {
+	var configPath string
+
+	// Initialize an empty configuration object that will be populated with
+	// any passed CLI flags for later merging.
+	cliConfig := &structs.FailsafeMode{
+		Config: &structs.Config{},
+	}
+
+	// Initialize command flags.
+	flags := c.Meta.FlagSet("failsafe", FlagSetClient)
+	flags.Usage = func() { c.UI.Error(c.Help()) }
+
+	// General configuration flags.
+	flags.StringVar(&configPath, "config", "", "")
+	flags.StringVar(&cliConfig.Config.Consul, "consul", "", "")
+	flags.StringVar(&cliConfig.Config.ConsulToken, "consul-token", "", "")
+	flags.StringVar(&cliConfig.Config.ConsulKeyLocation,
+		"consul-key-location", "", "")
+
+	// Failsafe mode configuration flags.
+	flags.BoolVar(&cliConfig.Enable, "enable", false, "Enable failsafe mode")
+	flags.BoolVar(&cliConfig.Disable, "disable", false, "Disable failsafe mode")
+	flags.BoolVar(&cliConfig.Force, "force", false,
+		"Supress confirmation prompts.")
+
+	// Parse the passed CLI flags.
+	if err := flags.Parse(c.args); err != nil {
+		return nil
+	}
+
+	// Determine the appropriate verbage for confirmation prompts.
+	cliConfig.Verb = "enable"
+	if cliConfig.Disable {
+		cliConfig.Verb = "disable"
+	}
+
+	// Create default configuration object on which to base the merge.
+	config := base.DefaultConfig()
+
+	// If a configuration path has been specified, load configuration from the
+	// specified location.
+	if configPath != "" {
+		current, err := base.LoadConfig(configPath)
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error loading configuration from %s: %s",
+				configPath, err))
+			return nil
+		}
+
+		// Merge loaded configuration with the default configuration.
+		config = config.Merge(current)
+	}
+
+	// Merge passed CLI flags with the configuration derived from the defaults
+	// and optionally, the loaded configuration.
+	cliConfig.Config = config.Merge(cliConfig.Config)
+
+	return cliConfig
+}

--- a/command/failsafe.go
+++ b/command/failsafe.go
@@ -52,7 +52,7 @@ Usage: replicator failsafe [options]
     -consul-key-location=<key>
       The Consul Key/Value Store location that Replicator will use
       for persistent configuration, state tracking and job scaling policies.
-			By default, this is replicator/config.
+      By default, this is replicator/config.
 
     -consul-token=<token>
       The Consul ACL token to use when communicating with an ACL
@@ -61,7 +61,7 @@ Usage: replicator failsafe [options]
   Failsafe Mode Options:
 
     -disable
-      Disable the global failsafe lock. All copies of Replicator wil
+      Disable the global failsafe lock. All copies of Replicator will
       return to normal operations.
 
     -enable

--- a/commands.go
+++ b/commands.go
@@ -36,6 +36,11 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"failsafe": func() (cli.Command, error) {
+			return &command.FailsafeCommand{
+				Meta: meta,
+			}, nil
+		},
 		"version": func() (cli.Command, error) {
 			ver := version.Version
 			rel := version.VersionPrerelease

--- a/replicator/failsafe.go
+++ b/replicator/failsafe.go
@@ -1,0 +1,67 @@
+package replicator
+
+import (
+	"fmt"
+
+	"github.com/elsevier-core-engineering/replicator/logging"
+	"github.com/elsevier-core-engineering/replicator/replicator/structs"
+)
+
+// FailsafeCheck determines if any critical failure modes have been detected
+// and if so, automatically places Replicator in failsafe mode.
+func FailsafeCheck(state *structs.State, config *structs.Config) (passing bool) {
+	// Assume we're in a good state until proven otherwise.
+	passing = true
+
+	// If attempts to launch new worker pool nodes have failed and we've
+	// reached or exceeded the retry threshold, we should put the daemon in
+	// failsafe mode.
+	if state.NodeFailureCount >= config.ClusterScaling.RetryThreshold {
+		passing = false
+	}
+
+	switch passing {
+	case true:
+		logging.Debug("core/failsafe: the failsafe check passes, scaling " +
+			"evaluations and operations will be permitted.")
+	case false:
+		SetFailsafeMode(state, config, true)
+	}
+
+	return
+}
+
+// SetFailsafeMode is used to toggle the global failsafe lock.
+func SetFailsafeMode(state *structs.State, config *structs.Config, enabled bool) (err error) {
+	switch enabled {
+	case true:
+		if !state.FailsafeMode {
+			// TODO (e.westfall) Send notification here after we've sorted
+			// notification client initialization.
+		}
+
+		// Suppress logging output if we're being called from the CLI tools.
+		if !state.FailsafeModeAdmin {
+			logging.Warning("core/failsafe: Replicator has been placed in failsafe " +
+				"mode. No scaling evaluations or operations will be permitted from " +
+				"any running copies of Replicator.")
+		}
+
+	case false:
+		if !state.FailsafeModeAdmin {
+			logging.Info("core/failsafe: exiting failsafe mode")
+		}
+	}
+
+	// Set the failsafe mode flag in the state object.
+	state.FailsafeMode = enabled
+
+	// Attempt to update the persistent state tracking data.
+	err = config.ConsulClient.WriteState(config, state)
+	if err != nil {
+		return fmt.Errorf("core/failsafe: an attempt to update the persistent "+
+			"state tracking data failed: %v", err)
+	}
+
+	return nil
+}

--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -37,7 +37,7 @@ func (r *Runner) Start() {
 	ticker := time.NewTicker(time.Second * time.Duration(r.config.ScalingInterval))
 
 	// Initialize the state tracking object for scaling operations.
-	scalingState := &structs.ScalingState{}
+	state := &structs.State{}
 
 	// Setup our LeaderCandidate object for leader elections and session renewl.
 	leaderKey := r.config.ConsulKeyLocation + "/" + "leader"
@@ -48,17 +48,19 @@ func (r *Runner) Start() {
 	for {
 		select {
 		case <-ticker.C:
+			// Attempt to load state tracking information from Consul.
+			state = r.config.ConsulClient.LoadState(r.config, state)
 
 			// Perform the leadership locking and continue if we have confirmed that
 			// we are running as the replicator leader.
 			r.candidate.leaderElection()
-			if r.candidate.isLeader() {
+			if r.candidate.isLeader() && FailsafeCheck(state, r.config) {
 
 				// ClusterScaling blocks Replicator when it runs, we do not want job
 				// scaling to be invoked if we are moving workloads around or adding
 				// new capacity.
 				clusterChan := make(chan bool)
-				go r.clusterScaling(clusterChan, scalingState)
+				go r.clusterScaling(clusterChan, state)
 				<-clusterChan
 
 				r.jobScaling()
@@ -80,14 +82,10 @@ func (r *Runner) Stop() {
 // clusterScaling is the main entry point into the cluster scaling functionality
 // and ties numerous functions together to create an asynchronus function which
 // can be called from the runner.
-func (r *Runner) clusterScaling(done chan bool, scalingState *structs.ScalingState) {
+func (r *Runner) clusterScaling(done chan bool, state *structs.State) {
 	// Initialize clients for Nomad and Consul.
 	nomadClient := r.config.NomadClient
 	consulClient := r.config.ConsulClient
-
-	// Attempt to load state tracking information from the distributed key/value
-	// store and reset permitted flag.
-	scalingState = consulClient.LoadState(r.config, scalingState)
 
 	// Retrieve value of cluster scaling enabled flag.
 	scalingEnabled := r.config.ClusterScaling.Enabled
@@ -117,8 +115,8 @@ func (r *Runner) clusterScaling(done chan bool, scalingState *structs.ScalingSta
 	asgSess := client.NewAWSAsgService(r.config.Region)
 
 	// Calculate the scaling cooldown threshold.
-	if !scalingState.LastScalingEvent.IsZero() {
-		cooldown := scalingState.LastScalingEvent.Add(
+	if !state.LastScalingEvent.IsZero() {
+		cooldown := state.LastScalingEvent.Add(
 			time.Duration(r.config.ClusterScaling.CoolDown) * time.Second)
 
 		if time.Now().Before(cooldown) {
@@ -161,10 +159,10 @@ func (r *Runner) clusterScaling(done chan bool, scalingState *structs.ScalingSta
 
 		// Attempt to add a new node to the worker pool until we reach the
 		// retry threshold.
-		for scalingState.NodeFailureCount <= r.config.ClusterScaling.RetryThreshold {
-			if scalingState.NodeFailureCount > 0 {
+		for state.NodeFailureCount <= r.config.ClusterScaling.RetryThreshold {
+			if state.NodeFailureCount > 0 {
 				logging.Info("core/runner: attempting to launch a new worker node, "+
-					"previous node failures: %v", scalingState.NodeFailureCount)
+					"previous node failures: %v", state.NodeFailureCount)
 			}
 
 			// We've verified the autoscaling group operation completed
@@ -177,11 +175,11 @@ func (r *Runner) clusterScaling(done chan bool, scalingState *structs.ScalingSta
 			if err != nil {
 				logging.Error("core/runner: Failed to identify the most recently "+
 					"launched instance: %v", err)
-				scalingState.NodeFailureCount++
-				scalingState.LastNodeFailure = time.Now()
+				state.NodeFailureCount++
+				state.LastNodeFailure = time.Now()
 
 				// Attempt to update state tracking information in Consul.
-				err = consulClient.WriteState(r.config, scalingState)
+				err = consulClient.WriteState(r.config, state)
 				if err != nil {
 					logging.Error("core/runner: %v", err)
 				}
@@ -192,13 +190,13 @@ func (r *Runner) clusterScaling(done chan bool, scalingState *structs.ScalingSta
 			// and successfully joined the worker pool.
 			if healthy := nomadClient.VerifyNodeHealth(newestNode); healthy {
 				// Reset node failure count once we have a verified healthy worker.
-				scalingState.NodeFailureCount = 0
+				state.NodeFailureCount = 0
 
 				// Update the last scaling event timestamp.
-				scalingState.LastScalingEvent = time.Now()
+				state.LastScalingEvent = time.Now()
 
 				// Attempt to update state tracking information in Consul.
-				err = consulClient.WriteState(r.config, scalingState)
+				err = consulClient.WriteState(r.config, state)
 				if err != nil {
 					logging.Error("core/runner: %v", err)
 				}
@@ -207,14 +205,14 @@ func (r *Runner) clusterScaling(done chan bool, scalingState *structs.ScalingSta
 				return
 			}
 
-			scalingState.NodeFailureCount++
-			scalingState.LastNodeFailure = time.Now()
+			state.NodeFailureCount++
+			state.LastNodeFailure = time.Now()
 			logging.Error("core/runner: new node %v failed to successfully join "+
 				"the worker pool, incrementing node failure count to %v and "+
-				"terminating instance", newestNode, scalingState.NodeFailureCount)
+				"terminating instance", newestNode, state.NodeFailureCount)
 
 			// Attempt to update state tracking information in Consul.
-			err = consulClient.WriteState(r.config, scalingState)
+			err = consulClient.WriteState(r.config, state)
 			if err != nil {
 				logging.Error("core/runner: %v", err)
 			}
@@ -225,13 +223,9 @@ func (r *Runner) clusterScaling(done chan bool, scalingState *structs.ScalingSta
 			// instance ID.
 			instanceID := client.TranslateIptoID(newestNode, r.config.Region)
 
-			// If we've reached the retry threshold, disable cluster scaling and
-			// halt.
-			if disabled := r.disableClusterScaling(scalingState); disabled {
-				// Detach the last failed instance and decrement the desired count
-				// of the autoscaling group. This will leave the instance around
-				// for debugging purposes but allow us to cleanly resume cluster
-				// scaling without intervention.
+			// If we've reached the retry threshold, attempt to detach the last
+			// failed instance and decrement the autoscaling group desired count.
+			if state.NodeFailureCount == r.config.ClusterScaling.RetryThreshold {
 				err := client.DetachInstance(
 					r.config.ClusterScaling.AutoscalingGroup, instanceID, asgSess,
 				)
@@ -282,10 +276,10 @@ func (r *Runner) clusterScaling(done chan bool, scalingState *structs.ScalingSta
 			}
 
 			// Update the last scaling event timestamp.
-			scalingState.LastScalingEvent = time.Now()
+			state.LastScalingEvent = time.Now()
 
 			// Attempt to update state tracking information in Consul.
-			err = consulClient.WriteState(r.config, scalingState)
+			err = consulClient.WriteState(r.config, state)
 			if err != nil {
 				logging.Error("core/runner: %v", err)
 			}
@@ -296,20 +290,20 @@ func (r *Runner) clusterScaling(done chan bool, scalingState *structs.ScalingSta
 	return
 }
 
-func (r *Runner) disableClusterScaling(scalingState *structs.ScalingState) (disabled bool) {
-	// If we've reached the retry threshold, disable cluster scaling and
-	// halt.
-	if scalingState.NodeFailureCount == r.config.ClusterScaling.RetryThreshold {
-		disabled = true
-		r.config.ClusterScaling.Enabled = false
-
-		logging.Error("core/runner: attempts to add new nodes to the "+
-			"worker pool have failed %v times. Cluster scaling will be "+
-			"disabled.", r.config.ClusterScaling.RetryThreshold)
-	}
-
-	return
-}
+// func (r *Runner) disableClusterScaling(scalingState *structs.State) (disabled bool) {
+// 	// If we've reached the retry threshold, disable cluster scaling and
+// 	// halt.
+// 	if scalingState.NodeFailureCount == r.config.ClusterScaling.RetryThreshold {
+// 		disabled = true
+// 		r.config.ClusterScaling.Enabled = false
+//
+// 		logging.Error("core/runner: attempts to add new nodes to the "+
+// 			"worker pool have failed %v times. Cluster scaling will be "+
+// 			"disabled.", r.config.ClusterScaling.RetryThreshold)
+// 	}
+//
+// 	return
+// }
 
 // jobScaling is the main entry point for the Nomad job scaling functionality
 // and ties together a number of functions to be called from the runner.

--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -290,21 +290,6 @@ func (r *Runner) clusterScaling(done chan bool, state *structs.State) {
 	return
 }
 
-// func (r *Runner) disableClusterScaling(scalingState *structs.State) (disabled bool) {
-// 	// If we've reached the retry threshold, disable cluster scaling and
-// 	// halt.
-// 	if scalingState.NodeFailureCount == r.config.ClusterScaling.RetryThreshold {
-// 		disabled = true
-// 		r.config.ClusterScaling.Enabled = false
-//
-// 		logging.Error("core/runner: attempts to add new nodes to the "+
-// 			"worker pool have failed %v times. Cluster scaling will be "+
-// 			"disabled.", r.config.ClusterScaling.RetryThreshold)
-// 	}
-//
-// 	return
-// }
-
 // jobScaling is the main entry point for the Nomad job scaling functionality
 // and ties together a number of functions to be called from the runner.
 func (r *Runner) jobScaling() {

--- a/replicator/structs/consul.go
+++ b/replicator/structs/consul.go
@@ -78,13 +78,13 @@ type ConsulClient interface {
 
 	// WriteState is responsible for persistently storing state tracking
 	// information in the Consul Key/Value Store.
-	WriteState(*Config, *ScalingState) error
+	WriteState(*Config, *State) error
 
 	// LoadState attempts to read state tracking information from the Consul
 	// Key/Value Store. If state tracking information is present, it will be
 	// preferred. If no persistent data is available, the method returns the
 	// state tracking object unmodified.
-	LoadState(*Config, *ScalingState) *ScalingState
+	LoadState(*Config, *State) *State
 
 	CreateSession(int, chan struct{}) (string, error)
 

--- a/replicator/structs/failsafe.go
+++ b/replicator/structs/failsafe.go
@@ -1,0 +1,20 @@
+package structs
+
+// FailsafeMode is the configuration struct for administratively interacting
+// with the global failsafe lock.
+type FailsafeMode struct {
+	// Config stores partial configuration required to interact with Consul.
+	Config *Config
+
+	// Disable instructs the failsafe CLI command to disable failsafe mode.
+	Disable bool
+
+	// Enable instructs the failsafe CLI command to enable failsafe mode.
+	Enable bool
+
+	// Force supresses confirmation prompts when enabling/disabling failsafe.
+	Force bool
+
+	// Verb represents the action to be displayed during confirmation prompts.
+	Verb string
+}

--- a/replicator/structs/nomad.go
+++ b/replicator/structs/nomad.go
@@ -64,16 +64,17 @@ type NomadClient interface {
 	VerifyNodeHealth(string) bool
 }
 
-// ScalingState is the central object for managing and storing all cluster
+// State is the central object for managing and storing all cluster
 // scaling state information.
-// TODO (e.westfall): Information in this struct should be persisted, see
-// GH-83 for more details.
-type ScalingState struct {
+type State struct {
 	// FailsafeMode tracks whether the daemon has exceeded the fault threshold
 	// while attempting to perform scaling operations. When operating in failsafe
 	// mode, the daemon will decline to take scaling actions of any type.
-	// TODO (e.westfall): Implement failover mode functionality.
 	FailsafeMode bool `json:"failsafe_mode"`
+
+	// Tracks whether the last failsafe mode change was initiated by an
+	// operator via the CLI.
+	FailsafeModeAdmin bool `json:"failsafe_mode_admin"`
 
 	// LastNodeFailure represents the last time a new worker node was launched
 	// and failed to successfully join the worker pool.


### PR DESCRIPTION
This commit introduces a distributed failsafe lock
that will prevent all running copies of Replicator
from taking any scaling actions if the daemon
detects enough consecutive critical failures to 
exceed the configured threshold.

Once a Replicator daemon has autonomously entered
failsafe mode, the lock flag is stored permanently
in the state tracking data. This allows the lock
to persist past daemon restarts, changes in leader
election or new copies of Replicator starting. To
resume normal behavior, an operator must explicitly
remove the failsafe lock.

This commit introduces a new CLI command,
`replicator failsafe`, that allows an operator to
administratively control the distributed failsafe
lock.

To implement this change, some restructuring of
the command package was required to allow the
new `replicator failsafe` command to access partial
configuration after merge and to initialize the
necessary clients to interact with Consul.

Closes #86.