### PR TITLE
Update LoadState and WriteState methods to use dynamic key path.

### DIFF
--- a/client/consul.go
+++ b/client/consul.go
@@ -87,9 +87,8 @@ func (c *consulClient) GetJobScalingPolicies(config *structs.Config, nomadClient
 // deserialized and returned as a state tracking object. If no persistent
 // data is available, the method returns the state tracking object unmodified.
 func (c *consulClient) LoadState(config *structs.Config, state *structs.State) *structs.State {
-	// TODO (e.westfall): Convert to using base path from configuration, see
-	// GH-94 for further details.
-	stateKey := "replicator/config/state"
+
+	stateKey := config.ConsulKeyLocation + "/" + "state"
 
 	logging.Debug("client/consul: attempting to load state tracking "+
 		"information from Consul at location %v", stateKey)
@@ -139,9 +138,8 @@ func (c *consulClient) LoadState(config *structs.Config, state *structs.State) *
 // WriteState is responsible for persistently storing state tracking
 // information in the Consul Key/Value Store.
 func (c *consulClient) WriteState(config *structs.Config, state *structs.State) (err error) {
-	// TODO (e.westfall): Convert to using base path from configuration, see
-	// GH-94 for further details.
-	stateKey := "replicator/config/state"
+
+	stateKey := config.ConsulKeyLocation + "/" + "state"
 
 	logging.Debug("client/consul: attempting to persistently store scaling "+
 		"state in Consul at location %v", stateKey)


### PR DESCRIPTION
This was previously hardcoded pending an update to the way in
which ConsulKeyLocation worked and was defaulted to. The change
has been completed and therefore the stateKey assignment can now
be performed dynamically using that config setting with state
prepended.

Closes #106