### PR TITLE
Evaluate cluster-node count against ASG desired before scaling.

### DIFF
--- a/client/aws.go
+++ b/client/aws.go
@@ -71,12 +71,13 @@ func ScaleOutCluster(asgName string, nodeCount int, svc *autoscaling.AutoScaling
 	maxSize := *asg.AutoScalingGroups[0].MaxSize
 
 	if desiredCap != int64(nodeCount) {
-		return fmt.Errorf("asg desired capacity %v does not Nomad worker pool count %v",
-			desiredCap, nodeCount)
+		return fmt.Errorf("asg desired capacity %v does not match the current "+
+			"Nomad worker pool count %v", desiredCap, nodeCount)
 	}
 
 	if desiredCap+int64(1) > maxSize {
-		return fmt.Errorf("incrementing asg count would violate asg max size of %v", maxSize)
+		return fmt.Errorf("incrementing asg count would violate asg max size of %v",
+			maxSize)
 	}
 
 	// The DesiredCapacity is incramented by 1, while the TerminationPolicies and
@@ -331,7 +332,8 @@ func checkClusterScalingResult(activityID *string, svc *autoscaling.AutoScaling)
 	for {
 		select {
 		case <-timeOut:
-			return fmt.Errorf("timeout %v reached on checking scaling activity success", timeOut)
+			return fmt.Errorf("timeout %v reached on checking scaling activity "+
+				"success", timeOut)
 		case <-ticker.C:
 
 			// Make a call to the AWS API every tick to ensure we get the latest Info
@@ -386,16 +388,18 @@ func TerminateInstance(instanceID, region string) error {
 	ticker := time.NewTicker(time.Second * time.Duration(10))
 	timeOut := time.Tick(time.Minute * 3)
 
-	logging.Info("client/aws: confirming successful termination of %s", instanceID)
+	logging.Info("client/aws: confirming successful termination of %s",
+		instanceID)
 
 	for {
 		select {
 		case <-timeOut:
-			return fmt.Errorf("timeout %v reached on checking instance %s termination", timeOut, instanceID)
+			return fmt.Errorf("timeout %v reached on checking instance %s "+
+				"termination", timeOut, instanceID)
 		case <-ticker.C:
 
-			// Setup the parameters to call the InstanceStatus endpoint so that we can
-			// discover the status of the terminating instance.
+			// Setup the parameters to call the InstanceStatus endpoint so that we
+			// can discover the status of the terminating instance.
 			params := &ec2.DescribeInstanceStatusInput{
 				DryRun:              aws.Bool(false),
 				IncludeAllInstances: aws.Bool(true),
@@ -410,7 +414,8 @@ func TerminateInstance(instanceID, region string) error {
 			}
 
 			if *resp.InstanceStatuses[0].InstanceState.Name == "terminated" {
-				logging.Info("client/aws: successful termination of %s confirmed", instanceID)
+				logging.Info("client/aws: successful termination of %s confirmed",
+					instanceID)
 
 				metrics.IncrCounter([]string{"cluster", "aws", "instance_terminations"}, 1)
 

--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -148,7 +148,7 @@ func (r *Runner) clusterScaling(done chan bool, state *structs.State) {
 
 		// Attempt to increment the desired count of the autoscaling group. If
 		// this fails, log an error and stop further processing.
-		err := client.ScaleOutCluster(r.config.ClusterScaling.AutoscalingGroup, asgSess)
+		err := client.ScaleOutCluster(r.config.ClusterScaling.AutoscalingGroup, clusterCapacity.NodeCount, asgSess)
 		if err != nil {
 			logging.Error("core/runner: unable to successfully initiate a "+
 				"scaling operation against autoscaling group %v: %v",


### PR DESCRIPTION
This change brings in an evaluation between the desired ASG count
and the Nomad worker pool before scaling the cluster out. This
stops us incrementing the ASG count further if we have no need to
as Replicator tracks node launches and failures to join the
cluster.

ScaleOut will now also perform a check against the ASG MaxSize
before incrementing the count; as if the incrementation were to
violate the MaxSize the AWS call would fail anyway.

Closes #70 