### PR TITLE
Add Failsafe Mode Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,25 @@ A [puppet module](https://github.com/elsevier-core-engineering/puppet-replicator
 
 Replicator supports a number of commands (CLI) which allow for the easy control and manipulation of the replicator binary.
 
-### Command: agent
+### Command: `agent`
 
-The agent command is the main entry point into Replicator. A subset of the available replicator agent configuration can optionally be passed in via CLI arguments and the configuration parameters passed via CLI flags will always take precedent over parameters specified in configuration files. Detailed information regarding the available CLI flags can be found in the Replicator [Agent Configuration wiki page](https://github.com/elsevier-core-engineering/replicator/wiki/Agent_Configuration#command-line-flags).
+The `agent` command is the main entry point into Replicator. A subset of the available replicator agent configuration can optionally be passed in via CLI arguments and the configuration parameters passed via CLI flags will always take precedent over parameters specified in configuration files.
 
-### Command: init
+Detailed information regarding the available CLI flags can be found in the Replicator [Agent Configuration wiki page](https://github.com/elsevier-core-engineering/replicator/wiki/Agent_Configuration#command-line-flags).
 
-The init command creates an example job scaling document in the current directory. This document can then be manipulated to meet your requirements, or be used to test replicator against the [Nomad init](https://www.nomadproject.io/docs/commands/init.html) example job.
+### Command: `failsafe`
 
-### Command: version
+The `failsafe` command is used to toggle failsafe mode across the pool of Replicator agents. Failsafe mode prevents any Replicator agent from taking any scaling actions.
 
-The version command displays build information about the running binary, including the release version.
+Detailed information about failsafe mode operations and the available CLI options can be found in the Replicator [Failsafe Mode wiki page](https://github.com/elsevier-core-engineering/replicator/wiki/Failsafe_Mode).
+
+### Command: `init`
+
+The `init` command creates an example job scaling document in the current directory. This document can then be manipulated to meet your requirements, or be used to test replicator against the [Nomad init](https://www.nomadproject.io/docs/commands/init.html) example job.
+
+### Command: `version`
+
+The `version` command displays build information about the running binary, including the release version.
 
 ## Configuration File Syntax
 


### PR DESCRIPTION
This commit adds documentation for the `failsafe` command in the README and also provides more detailed documentation in the form of the following Wiki page:

```
Replicator is designed to automatically detect critical failures during scaling operations. If enough consecutive failures are detected, the failsafe circuit breaker trips and Replicator enters failsafe mode.

When operating in failsafe mode, all running copies of Replicator will be prevented from taking any scaling actions. This behavior is designed to prevent Replicator from further complicating a potentially malfunctioning cluster.

## State Persistence

Once Replicator has detected enough consecutive critical faults and the failsafe circuit breaker has been tripped, the failsafe lock flag is persistently updated in the state tracking data shared by all Replicator agents. This allows the failsafe lock to persist past daemon restarts, changes in leader election or the introduction of new Replicator agents to the pool.

To exit failsafe mode, an operator must **explicitly** reset the failsafe circuit breaker by running the `replicator failsafe -disable` command.

## Critical Failures

Replicator will autonomously enter failsafe mode when enough consecutive critical faults are detected. The following critical faults will trip the failsafe circuit breaker:

- New worker pool nodes fail to launch or fail to successfully join the worker pool.

  The maximum threshold is set by the `cluster-retry-threshold` CLI flag or the `cluster_scaling::retry_threshold` configuration parameter.

## Command Line Interface

The Replicator CLI includes the `failsafe` command to administratively control failsafe mode.

### Usage

```replicator failsafe [options]```

It is required to pass one of `-enable` or `-disable`, depending on which operation is desired.

By default, if the desired operation will result in a state change, a confirmation prompt will be displayed before proceeding. You can override this behavior by passing the `-force` flag.

If the current state matches the desired state, a message will be displayed and no action is taken.

### General Options

`-config=<path>`   
    The path to either a single config file or a directory of config
    files to use when configuring the Replicator agent. Replicator
    processes configuration files in lexicographic order.

  `-consul=<address:port>`    
    This is the address of the Consul agent. By default, this is
    localhost:8500, which is the default bind and port for a local
    Consul agent. It is not recommended that you communicate directly
    with a Consul server, and instead communicate with the local
    Consul agent. There are many reasons for this, most importantly
    the Consul agent is able to multiplex connections to the Consul
    server and reduce the number of open HTTP connections. Additionally,
    it provides a "well-known" IP address for which clients can connect.

  `-consul-key-location=<key>`    
    The Consul Key/Value Store location that Replicator will use
    for persistent configuration, state tracking and job scaling policies.
    By default, this is replicator/config.

  `-consul-token=<token>`    
    The Consul ACL token to use when communicating with an ACL
    protected Consul cluster.

### Failsafe Mode Options

`-disable`    
  Disable the global failsafe lock. All copies of Replicator wil
  return to normal operations.

`-enable`     
  Enable the global failsafe lock. All copies of Replicator will
  be prohibited from taking any scaling actions.

`-force`    
  Suppress confirmation prompts when enabling or disabling the
  global failsafe lock.

```

Closes #109 