### PR TITLE
Always Fail Failsafe Circuit Breaker After Trip

### DIFF
--- a/command/failsafe.go
+++ b/command/failsafe.go
@@ -81,9 +81,9 @@ func (c *FailsafeCommand) Synopsis() string {
 }
 
 // Run triggers the failsafe command to update the distributed state tracking
-// data and manipulate the failsafe lock.
+// data and manipulate the distributed failsafe lock.
 func (c *FailsafeCommand) Run(args []string) int {
-	// Initialize an new empty state tracking object.
+	// Initialize a new empty state tracking object.
 	state := &structs.State{}
 
 	// The operator must specify at least one operation.

--- a/replicator/structs/failsafe.go
+++ b/replicator/structs/failsafe.go
@@ -1,7 +1,7 @@
 package structs
 
 // FailsafeMode is the configuration struct for administratively interacting
-// with the global failsafe lock.
+// with the distributed failsafe lock.
 type FailsafeMode struct {
 	// Config stores partial configuration required to interact with Consul.
 	Config *Config


### PR DESCRIPTION
This commit fixes #112 by ensuring the failsafe
mode circuit breaker will always fail properly
once tripped automatically or via administrative
interface.

Closes #112 