### PR TITLE
ClusterScalingTheshold parameter is now used to determine scaling.

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -132,6 +132,7 @@ func (c *Command) parseFlags() *structs.Config {
 	flags.IntVar(&cliConfig.ClusterScaling.NodeFaultTolerance, "cluster-node-fault-tolerance", 0, "")
 	flags.StringVar(&cliConfig.ClusterScaling.AutoscalingGroup, "cluster-autoscaling-group", "", "")
 	flags.IntVar(&cliConfig.ClusterScaling.RetryThreshold, "cluster-retry-threshold", 0, "")
+	flags.IntVar(&cliConfig.ClusterScaling.ScalingThreshold, "cluster-scaling-threshold", 0, "")
 
 	// Job scaling configuration flags
 	flags.BoolVar(&cliConfig.JobScaling.Enabled, "job-scaling-enabled", false, "")
@@ -324,6 +325,12 @@ func (c *Command) Help() string {
       Indicates whether the daemon should perform scaling actions. If
       disabled, the actions that would have been taken will be reported
       in the logs but skipped.
+
+    -cluster-scaling-threshold
+      This is the number of consecutive times Replicator must calculate
+      that a cluster scaling action should be invoked, before the action
+      is triggered. This used in conjunction with the scaling-interval
+      helps prevent trashing of the cluster to fleeting load changes.
 
   Job Scaling Options:
 

--- a/command/base/config.go
+++ b/command/base/config.go
@@ -34,6 +34,7 @@ func DefaultConfig() *structs.Config {
 			CoolDown:           600,
 			NodeFaultTolerance: 1,
 			RetryThreshold:     2,
+			ScalingThreshold:   3,
 		},
 
 		JobScaling: &structs.JobScaling{},
@@ -61,6 +62,7 @@ func DevConfig() *structs.Config {
 			CoolDown:           0,
 			NodeFaultTolerance: 0,
 			RetryThreshold:     1,
+			ScalingThreshold:   1,
 		},
 
 		JobScaling: &structs.JobScaling{},

--- a/command/base/config_parse.go
+++ b/command/base/config_parse.go
@@ -148,6 +148,7 @@ func parseClusterScaling(result **structs.ClusterScaling, list *ast.ObjectList) 
 		"node_fault_tolerance",
 		"autoscaling_group",
 		"retry_threshold",
+		"scaling_threshold",
 	}
 	if err := checkHCLKeys(listVal, valid); err != nil {
 		return err

--- a/replicator/cluster_scaling.go
+++ b/replicator/cluster_scaling.go
@@ -1,0 +1,43 @@
+package replicator
+
+import (
+	"github.com/elsevier-core-engineering/replicator/client"
+	"github.com/elsevier-core-engineering/replicator/logging"
+	"github.com/elsevier-core-engineering/replicator/replicator/structs"
+)
+
+func checkScalingThreshold(state *structs.State, direction string, clusterScaling *structs.ClusterScaling) (scale bool) {
+
+	switch direction {
+	case client.ScalingDirectionIn:
+		state.ClusterScaleInRequests++
+		state.ClusterScaleOutRequests = 0
+		if state.ClusterScaleInRequests == clusterScaling.ScalingThreshold {
+			state.ClusterScaleInRequests = 0
+			logging.Debug("core/cluster_scaling: scale in requests %v has reached threshold %v",
+				state.ClusterScaleInRequests, clusterScaling.ScalingThreshold)
+			return true
+		}
+
+		logging.Debug("core/cluster_scaling: scale in requests %v has not been reached threshold %v",
+			state.ClusterScaleInRequests, clusterScaling.ScalingThreshold)
+
+	case client.ScalingDirectionOut:
+		state.ClusterScaleOutRequests++
+		state.ClusterScaleInRequests = 0
+		if state.ClusterScaleOutRequests == clusterScaling.ScalingThreshold {
+			state.ClusterScaleOutRequests = 0
+			logging.Debug("core/cluster_scaling: scale out requests %v has reached threshold %v",
+				state.ClusterScaleInRequests, clusterScaling.ScalingThreshold)
+			return true
+		}
+
+		logging.Debug("core/cluster_scaling: scale out requests %v has not been reached threshold %v",
+			state.ClusterScaleOutRequests, clusterScaling.ScalingThreshold)
+
+	default:
+		state.ClusterScaleInRequests = 0
+		state.ClusterScaleOutRequests = 0
+	}
+	return
+}

--- a/replicator/cluster_scaling_test.go
+++ b/replicator/cluster_scaling_test.go
@@ -1,0 +1,47 @@
+package replicator
+
+import (
+	"testing"
+
+	"github.com/elsevier-core-engineering/replicator/client"
+	"github.com/elsevier-core-engineering/replicator/replicator/structs"
+)
+
+func TestClusterScaling_scalingThreshold(t *testing.T) {
+
+	cluster := &structs.ClusterScaling{}
+	state := &structs.State{}
+	cluster.ScalingThreshold = 3
+
+	// Check ScaleOut scenarios.
+	state.ClusterScaleOutRequests = 2
+	if !checkScalingThreshold(state, client.ScalingDirectionOut, cluster) {
+		t.Fatal("expected ClusterScaleOut to answer true but got false")
+	}
+
+	state.ClusterScaleOutRequests = 1
+	if checkScalingThreshold(state, client.ScalingDirectionOut, cluster) {
+		t.Fatal("expected ClusterScaleOut to answer false but got true")
+	}
+
+	// Check ScaleIn scenarios.
+	state.ClusterScaleInRequests = 2
+	if !checkScalingThreshold(state, client.ScalingDirectionIn, cluster) {
+		t.Fatal("expected ClusterScaleIn to answer true but got false")
+	}
+
+	state.ClusterScaleInRequests = 1
+	if checkScalingThreshold(state, client.ScalingDirectionIn, cluster) {
+		t.Fatal("expected ClusterScaleIn to answer false but got true")
+	}
+
+	// Check the default return and state setting.
+	if checkScalingThreshold(state, client.ScalingDirectionNone, cluster) {
+		t.Fatal("expected ClusterScalingNone to answer false but got true")
+	}
+
+	if state.ClusterScaleInRequests != 0 || state.ClusterScaleOutRequests != 0 {
+		t.Fatalf("expected state scale requests to be 0, got %v and %v",
+			state.ClusterScaleInRequests, state.ClusterScaleOutRequests)
+	}
+}

--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -101,7 +101,6 @@ func (r *Runner) clusterScaling(done chan bool, state *structs.State) {
 	// Initialize a new disposable cluster capacity object.
 	clusterCapacity := &structs.ClusterCapacity{}
 
-	//if scale, err := nomadClient.EvaluateClusterCapacity(clusterCapacity, r.config); err != nil || !scale {
 	scale, err := nomadClient.EvaluateClusterCapacity(clusterCapacity, r.config)
 	if err != nil || !scale {
 		logging.Debug("core/runner: scaling operation not required or permitted")
@@ -135,7 +134,8 @@ func (r *Runner) clusterScaling(done chan bool, state *structs.State) {
 			"occurred, scaling operations will be permitted.")
 	}
 
-	if clusterCapacity.ScalingDirection == client.ScalingDirectionOut {
+	if clusterCapacity.ScalingDirection == client.ScalingDirectionOut &&
+		checkScalingThreshold(state, clusterCapacity.ScalingDirection, r.config.ClusterScaling) {
 		// If cluster scaling has been disabled, report but do not initiate a
 		// scaling operation.
 		if !scalingEnabled {
@@ -246,7 +246,8 @@ func (r *Runner) clusterScaling(done chan bool, state *structs.State) {
 		}
 	}
 
-	if clusterCapacity.ScalingDirection == client.ScalingDirectionIn {
+	if clusterCapacity.ScalingDirection == client.ScalingDirectionIn &&
+		checkScalingThreshold(state, clusterCapacity.ScalingDirection, r.config.ClusterScaling) {
 		// Attempt to identify the least-allocated node in the worker pool.
 		nodeID, nodeIP := nomadClient.LeastAllocatedNode(clusterCapacity)
 		if nodeIP != "" && nodeID != "" {

--- a/replicator/structs/config.go
+++ b/replicator/structs/config.go
@@ -79,6 +79,11 @@ type ClusterScaling struct {
 	// RetryPeriod is the number of times Replicator will retry scale-out when
 	// new nodes do not join the worker pool and reach the join timeout.
 	RetryThreshold int `mapstructure:"retry_threshold"`
+
+	// ScalingThreshold is the number of consecutive times Replicator determines
+	// as cluster scaling action should occur before that request is allowed to
+	// be enforced.
+	ScalingThreshold int `mapstructure:"scaling_threshold"`
 }
 
 // JobScaling is the configuration struct for the Nomad job scaling activities.
@@ -206,6 +211,10 @@ func (c *ClusterScaling) Merge(b *ClusterScaling) *ClusterScaling {
 
 	if b.RetryThreshold != 0 {
 		config.RetryThreshold = b.RetryThreshold
+	}
+
+	if b.ScalingThreshold != 0 {
+		config.ScalingThreshold = b.ScalingThreshold
 	}
 
 	return &config

--- a/replicator/structs/nomad.go
+++ b/replicator/structs/nomad.go
@@ -90,6 +90,14 @@ type State struct {
 	// NodeFailureCount tracks the number of worker nodes that have failed to
 	// successfully join the worker pool after a scale-out operation.
 	NodeFailureCount int `json:"node_failure_count"`
+
+	// ClusterScaleInRequests tracks the number of consecutive times replicator
+	// has indicated the cluster worker pool should be scaled in.
+	ClusterScaleInRequests int `json:"cluster_scalein_requests"`
+
+	// ClusterScaleOutRequests tracks the number of consecutive times replicator
+	// has indicated the cluster worker pool should be scaled out.
+	ClusterScaleOutRequests int `json:"cluster_scaleout_requests"`
 }
 
 // ClusterCapacity is the central object used to track and evaluate cluster


### PR DESCRIPTION
Previously Replicator would perform cluster scaling operations if
only the cool-down had been met; which met Replicator would scale
on fleeting load in the cluster.

To combat this, a new parameter, cluster-scaling-threshold has been
added. Replicator must now want to perform a cluster scaling action
for n consecutive times which is set by the new param before a
scaling operation will be actioned.

The default config value is set to 3 and 1 in the default and dev
configs respectively. Tests have also been added for the new func
within the replicator package.

Closes #73