### PR TITLE
Initialize notification backends and store in config struct.

### DIFF
--- a/notifier/pagerduty.go
+++ b/notifier/pagerduty.go
@@ -6,6 +6,8 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 )
 
+// PagerDutyProvider contains the required configuration to send PagerDuty
+// notifications.
 type PagerDutyProvider struct {
 	config map[string]string
 }

--- a/replicator/structs/config.go
+++ b/replicator/structs/config.go
@@ -1,5 +1,9 @@
 package structs
 
+import (
+	"github.com/elsevier-core-engineering/replicator/notifier"
+)
+
 // Config is the main configuration struct used to configure the replicator
 // application.
 type Config struct {
@@ -112,6 +116,10 @@ type Notification struct {
 
 	// PagerDutyServiceKey is the PD integration key for the Events API v1.
 	PagerDutyServiceKey string `mapstructure:"pagerduty_service_key"`
+
+	// Notifiers is where our initialize notification backends are stored so they
+	// can be used on the fly when required.
+	Notifiers []notifier.Notifier
 }
 
 // Merge merges two configurations.


### PR DESCRIPTION
Replicator now initializes configured notification backends and
stores these as a slice within the config struct. This then allows
notifications to be sent to each configured backend via a simple
for loop.

Closes #107 