### PR TITLE
Persist Initial State Tracking Information

### DIFF
--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -55,6 +55,11 @@ func (r *Runner) Start() {
 			// we are running as the replicator leader.
 			r.candidate.leaderElection()
 			if r.candidate.isLeader() && FailsafeCheck(state, r.config) {
+				// If there was no pre-existing state tracking information in Consul,
+				// persist an initial state tracking object.
+				if state.LastUpdated.IsZero() {
+					r.config.ConsulClient.WriteState(r.config, state)
+				}
 
 				// ClusterScaling blocks Replicator when it runs, we do not want job
 				// scaling to be invoked if we are moving workloads around or adding


### PR DESCRIPTION
This commit ensures Replicator will persistently
write state tracking information to the Consul
Key/Value Store if no pre-existing state tracking
information exists.

Before this change, no distributed state tracking
information would be available until a scaling
action was initiated.

Closes #120.