### PR TITLE
Protect Nomad Agent Node Running Replicator Leader

### DIFF
--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -56,6 +56,12 @@ func (r *Runner) Start() {
 			// we are running as the replicator leader.
 			r.candidate.leaderElection()
 			if r.candidate.isLeader() && FailsafeCheck(state, r.config) {
+				// If there was no pre-existing state tracking information in Consul,
+				// persist an initial state tracking object.
+				if state.LastUpdated.IsZero() {
+					r.config.ConsulClient.WriteState(r.config, state)
+				}
+
 				// If we're running as a Nomad job, perform a reverse lookup to
 				// identify the node on which we're running and register it as
 				// protected.

--- a/replicator/structs/nomad.go
+++ b/replicator/structs/nomad.go
@@ -44,13 +44,15 @@ type NomadClient interface {
 	// thresholds set.
 	JobScale(*JobScalingPolicy)
 
-	// LeaseAllocatedNode determines the worker node consuming the least amount of
-	// the cluster's mosted-utilized resource.
-	LeastAllocatedNode(*ClusterCapacity) (string, string)
+	// LeastAllocatedNode determines which worker pool node is consuming the
+	// least amount of the cluster's most-utilized resource. If Replicator is
+	// running as a Nomad job, the worker node running the Replicator leader will
+	// be excluded.
+	LeastAllocatedNode(*ClusterCapacity, *State) (string, string)
 
-	// LookupNode is responsible for performing reverse lookups of the Nomad Node
-	// ID by providing an allocation ID.
-	LookupNode(string) (string, error)
+	// NodeReverseLookup provides a method to get the ID of the worker pool node
+	// running a given allocation.
+	NodeReverseLookup(string) (string, error)
 
 	// MostUtilizedResource calculates which resource is most-utilized across the
 	// cluster. The worst-case allocation resource is prioritized when making
@@ -102,6 +104,11 @@ type State struct {
 	// NodeFailureCount tracks the number of worker nodes that have failed to
 	// successfully join the worker pool after a scale-out operation.
 	NodeFailureCount int `json:"node_failure_count"`
+
+	// ProtectedNode represents the Nomad agent node on which the Replicator
+	// leader is running. This node will be excluded when identifying an eligible
+	// node for termination during scaling actions.
+	ProtectedNode string `json:"protected_node"`
 }
 
 // ClusterCapacity is the central object used to track and evaluate cluster

--- a/replicator/structs/nomad.go
+++ b/replicator/structs/nomad.go
@@ -48,6 +48,10 @@ type NomadClient interface {
 	// the cluster's mosted-utilized resource.
 	LeastAllocatedNode(*ClusterCapacity) (string, string)
 
+	// LookupNode is responsible for performing reverse lookups of the Nomad Node
+	// ID by providing an allocation ID.
+	LookupNode(string) (string, error)
+
 	// MostUtilizedResource calculates which resource is most-utilized across the
 	// cluster. The worst-case allocation resource is prioritized when making
 	// scaling decisions.
@@ -67,6 +71,14 @@ type NomadClient interface {
 // State is the central object for managing and storing all cluster
 // scaling state information.
 type State struct {
+	// ClusterScaleInRequests tracks the number of consecutive times replicator
+	// has indicated the cluster worker pool should be scaled in.
+	ClusterScaleInRequests int `json:"cluster_scalein_requests"`
+
+	// ClusterScaleOutRequests tracks the number of consecutive times replicator
+	// has indicated the cluster worker pool should be scaled out.
+	ClusterScaleOutRequests int `json:"cluster_scaleout_requests"`
+
 	// FailsafeMode tracks whether the daemon has exceeded the fault threshold
 	// while attempting to perform scaling operations. When operating in failsafe
 	// mode, the daemon will decline to take scaling actions of any type.
@@ -90,14 +102,6 @@ type State struct {
 	// NodeFailureCount tracks the number of worker nodes that have failed to
 	// successfully join the worker pool after a scale-out operation.
 	NodeFailureCount int `json:"node_failure_count"`
-
-	// ClusterScaleInRequests tracks the number of consecutive times replicator
-	// has indicated the cluster worker pool should be scaled in.
-	ClusterScaleInRequests int `json:"cluster_scalein_requests"`
-
-	// ClusterScaleOutRequests tracks the number of consecutive times replicator
-	// has indicated the cluster worker pool should be scaled out.
-	ClusterScaleOutRequests int `json:"cluster_scaleout_requests"`
 }
 
 // ClusterCapacity is the central object used to track and evaluate cluster


### PR DESCRIPTION
This commit adds intelligence to Replicator to
determine if it is running as a Nomad job and if
so, to attempt to identify the agent node on which
it is running.

If the node is identified, it is registered in the
state tracking information as a protected node.
The least-allocated node discovery method has
been modified to exclude the protected node during
the discovery process.

This feature is only used by the elected Replicator
leader. If this feature encounters errors, the
original behavior is retained.

Closes #119.