### PR TITLE
Add DEBUG logging when leadership lock is not obtained.

### DIFF
--- a/replicator/leader.go
+++ b/replicator/leader.go
@@ -64,6 +64,7 @@ func (l *LeaderCandidate) leaderElection() (isLeader bool) {
 		return true
 	}
 
+	logging.Debug("core/leader: failed to aquire leadership lock")
 	return
 }
 


### PR DESCRIPTION
Previously Replicator logged that it was attempting to obtain a
lock but never reported if it couldn't obtain the lock. This
change adds a debug log message when this occurs.

Closes #121 