### PR TITLE
Replicator will send a notification if failsafe mode is enabled

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -377,9 +377,10 @@ func (c *Command) Help() string {
       which cluster is alerting.
 
     -cluster-scaling-uid=<uid>
-      The cluster UID is an identifier which represents a run book entry
-      which allows operators and support to quickly work through
-      resolution steps.
+      The cluster scaling UID is an identifier which represents a run book
+      entry relating to failsafe resolution guidelines. When a notification
+      is sent upon failsafe mode being enabled, the alert will include this
+      UID.
 
     -pagerduty-service-key=<key>
       The PagerDuty integration key which has been setup to allow

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -9,17 +9,15 @@ import (
 type FailureMessage struct {
 	AlertUID          string
 	ClusterIdentifier string
-	FailedNode        string
-	IncidentReason    string
-	NomadDataCentre   string
-	NomadRegion       string
+	Reason            string
+	FailedResource    string
 }
 
 // Notifier is the interface to the Notifiers functions. All notifers are
 // expected to implament this set of functions.
 type Notifier interface {
 	Name() string
-	SendNotification(FailureMessage) (string, error)
+	SendNotification(FailureMessage)
 }
 
 // NewProvider is the factory entrace to the notifications backends.

--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -212,6 +212,7 @@ func (r *Runner) clusterScaling(done chan bool, state *structs.State) {
 
 			state.NodeFailureCount++
 			state.LastNodeFailure = time.Now()
+			state.LastFailedNode = newestNode
 			logging.Error("core/runner: new node %v failed to successfully join "+
 				"the worker pool, incrementing node failure count to %v and "+
 				"terminating instance", newestNode, state.NodeFailureCount)

--- a/replicator/structs/nomad.go
+++ b/replicator/structs/nomad.go
@@ -73,14 +73,6 @@ type NomadClient interface {
 // State is the central object for managing and storing all cluster
 // scaling state information.
 type State struct {
-	// ClusterScaleInRequests tracks the number of consecutive times replicator
-	// has indicated the cluster worker pool should be scaled in.
-	ClusterScaleInRequests int `json:"cluster_scalein_requests"`
-
-	// ClusterScaleOutRequests tracks the number of consecutive times replicator
-	// has indicated the cluster worker pool should be scaled out.
-	ClusterScaleOutRequests int `json:"cluster_scaleout_requests"`
-
 	// FailsafeMode tracks whether the daemon has exceeded the fault threshold
 	// while attempting to perform scaling operations. When operating in failsafe
 	// mode, the daemon will decline to take scaling actions of any type.

--- a/replicator/structs/nomad.go
+++ b/replicator/structs/nomad.go
@@ -98,6 +98,10 @@ type State struct {
 	// ClusterScaleOutRequests tracks the number of consecutive times replicator
 	// has indicated the cluster worker pool should be scaled out.
 	ClusterScaleOutRequests int `json:"cluster_scaleout_requests"`
+
+	// LastFailedNode allows us to track the last node which was launched which
+	// failed to join the cluster.
+	LastFailedNode string `json:"last_failed_node"`
 }
 
 // ClusterCapacity is the central object used to track and evaluate cluster

--- a/replicator/structs/nomad.go
+++ b/replicator/structs/nomad.go
@@ -73,6 +73,14 @@ type NomadClient interface {
 // State is the central object for managing and storing all cluster
 // scaling state information.
 type State struct {
+	// ClusterScaleInRequests tracks the number of consecutive times replicator
+	// has indicated the cluster worker pool should be scaled in.
+	ClusterScaleInRequests int `json:"cluster_scalein_requests"`
+
+	// ClusterScaleOutRequests tracks the number of consecutive times replicator
+	// has indicated the cluster worker pool should be scaled out.
+	ClusterScaleOutRequests int `json:"cluster_scaleout_requests"`
+
 	// FailsafeMode tracks whether the daemon has exceeded the fault threshold
 	// while attempting to perform scaling operations. When operating in failsafe
 	// mode, the daemon will decline to take scaling actions of any type.
@@ -81,6 +89,10 @@ type State struct {
 	// Tracks whether the last failsafe mode change was initiated by an
 	// operator via the CLI.
 	FailsafeModeAdmin bool `json:"failsafe_mode_admin"`
+
+	// LastFailedNode allows us to track the last node which was launched which
+	// failed to join the cluster.
+	LastFailedNode string `json:"last_failed_node"`
 
 	// LastNodeFailure represents the last time a new worker node was launched
 	// and failed to successfully join the worker pool.
@@ -96,18 +108,6 @@ type State struct {
 	// NodeFailureCount tracks the number of worker nodes that have failed to
 	// successfully join the worker pool after a scale-out operation.
 	NodeFailureCount int `json:"node_failure_count"`
-
-	// ClusterScaleInRequests tracks the number of consecutive times replicator
-	// has indicated the cluster worker pool should be scaled in.
-	ClusterScaleInRequests int `json:"cluster_scalein_requests"`
-
-	// ClusterScaleOutRequests tracks the number of consecutive times replicator
-	// has indicated the cluster worker pool should be scaled out.
-	ClusterScaleOutRequests int `json:"cluster_scaleout_requests"`
-
-	// LastFailedNode allows us to track the last node which was launched which
-	// failed to join the cluster.
-	LastFailedNode string `json:"last_failed_node"`
 
 	// ProtectedNode represents the Nomad agent node on which the Replicator
 	// leader is running. This node will be excluded when identifying an eligible


### PR DESCRIPTION
Using the notification backends Replicator will now send a
notification to each backend when failsafe mode is entered.

Closes #116