### PR TITLE
Add Docker Image and Example Job Files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,19 +14,19 @@ ENV REPLICATOR_VERSION v0.0.2-alpha2
 
 WORKDIR /usr/local/bin/
 
-RUN			apk --no-cache add \
-				ca-certificates
+RUN     apk --no-cache add \
+        ca-certificates
 
 RUN buildDeps=' \
-								bash \
-								wget \
-				' \
-				set -x \
-				&& apk --no-cache add $buildDeps \
-				&& wget -O replicator https://github.com/elsevier-core-engineering/replicator/releases/download/${REPLICATOR_VERSION}/linux-amd64-replicator \
-				&& chmod +x /usr/local/bin/replicator \
-				&& apk del $buildDeps \
-				&& echo "Build complete."
+                bash \
+                wget \
+        ' \
+        set -x \
+        && apk --no-cache add $buildDeps \
+        && wget -O replicator https://github.com/elsevier-core-engineering/replicator/releases/download/${REPLICATOR_VERSION}/linux-amd64-replicator \
+        && chmod +x /usr/local/bin/replicator \
+        && apk del $buildDeps \
+        && echo "Build complete."
 
 ENTRYPOINT [ "replicator" ]
 CMD [ "agent", "--help" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Replicator is a daemon that provides automatic scaling of Nomad jobs and
+# worker nodes.
+#
+# docker run --rm -it \
+# 			 --name replicator \
+#				 elsce/replicator agent
+
+FROM alpine:edge
+LABEL maintainer Eric Westfall<(eawestfall@gmail.com> (@eawestfall)
+LABEL vendor "Elsevier Core Engineering"
+LABEL documentation "https://github.com/elsevier-core-engineering/replicator"
+
+ENV REPLICATOR_VERSION v0.0.2-alpha2
+
+WORKDIR /usr/local/bin/
+
+RUN			apk --no-cache add \
+				ca-certificates
+
+RUN buildDeps=' \
+								bash \
+								wget \
+				' \
+				set -x \
+				&& apk --no-cache add $buildDeps \
+				&& wget -O replicator https://github.com/elsevier-core-engineering/replicator/releases/download/${REPLICATOR_VERSION}/linux-amd64-replicator \
+				&& chmod +x /usr/local/bin/replicator \
+				&& apk del $buildDeps \
+				&& echo "Build complete."
+
+ENTRYPOINT [ "replicator" ]
+CMD [ "agent", "--help" ]

--- a/example-jobs/replicator-docker.nomad
+++ b/example-jobs/replicator-docker.nomad
@@ -16,25 +16,17 @@ job "replicator" {
     count = 2
 
     task "replicator" {
-      driver = "exec"
-
-      constraint {
-        attribute = "${attr.kernel.name}"
-        value     = "linux"
-      }
+      driver = "docker"
 
       config {
-        command = "${attr.kernel.name}-${attr.cpu.arch}-replicator"
-        args    = [
+        image        = "elsce/replicator:${NOMAD_META_VERSION}"
+        network_mode = "host"
+        args         = [
           "agent",
           "-aws-region=us-east-1",
           "-consul-token=CONSUL_ACL_TOKEN",
           "-cluster-autoscaling-group=WORKER_POOL_ASG_NAME",
         ]
-      }
-
-      artifact {
-        source = "https://github.com/elsevier-core-engineering/replicator/releases/download/${NOMAD_META_VERSION}/${attr.kernel.name}-${attr.cpu.arch}-replicator"
       }
 
       resources {

--- a/example-jobs/replicator-exec.nomad
+++ b/example-jobs/replicator-exec.nomad
@@ -1,0 +1,46 @@
+job "replicator" {
+  datacenters = ["dc1"]
+  region      = "global"
+  type        = "service"
+
+  update {
+    stagger      = "10s"
+    max_parallel = 1
+  }
+
+  group "replicator" {
+    count = 2
+
+    task "replicator" {
+      driver = "exec"
+
+      constraint {
+        attribute = "${attr.kernel.name}"
+        value     = "linux"
+      }
+
+      config {
+        command = "${attr.kernel.name}-${attr.cpu.arch}-replicator"
+        args    = [
+          "agent",
+          "-aws-region=us-east-1",
+          "-consul-token=CONSUL_ACL_TOKEN",
+          "-cluster-autoscaling-group=WORKER_POOL_ASG_NAME",
+        ]
+      }
+
+      artifact {
+        source = "https://github.com/elsevier-core-engineering/replicator/releases/download/0.0.2/${attr.kernel.name}-${attr.cpu.arch}-replicator"
+      }
+
+      resources {
+        cpu    = 250
+        memory = 60
+
+        network {
+          mbits = 5
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit introduces a source Docker image and
example Nomad job files to run Replicator in using
either the `exec` or `docker` driver.

Closes #102.