### PR TITLE
Replicator checkScalingThreshold now writes persistent state.

### DIFF
--- a/replicator/cluster_scaling.go
+++ b/replicator/cluster_scaling.go
@@ -6,38 +6,46 @@ import (
 	"github.com/elsevier-core-engineering/replicator/replicator/structs"
 )
 
-func checkScalingThreshold(state *structs.State, direction string, clusterScaling *structs.ClusterScaling) (scale bool) {
+func checkScalingThreshold(state *structs.State, direction string, config *structs.Config) (scale bool) {
 
 	switch direction {
 	case client.ScalingDirectionIn:
 		state.ClusterScaleInRequests++
 		state.ClusterScaleOutRequests = 0
-		if state.ClusterScaleInRequests == clusterScaling.ScalingThreshold {
+		if state.ClusterScaleInRequests == config.ClusterScaling.ScalingThreshold {
 			state.ClusterScaleInRequests = 0
 			logging.Debug("core/cluster_scaling: scale in requests %v has reached threshold %v",
-				state.ClusterScaleInRequests, clusterScaling.ScalingThreshold)
-			return true
+				state.ClusterScaleInRequests, config.ClusterScaling.ScalingThreshold)
+			scale = true
 		}
 
 		logging.Debug("core/cluster_scaling: scale in requests %v has not been reached threshold %v",
-			state.ClusterScaleInRequests, clusterScaling.ScalingThreshold)
+			state.ClusterScaleInRequests, config.ClusterScaling.ScalingThreshold)
 
 	case client.ScalingDirectionOut:
 		state.ClusterScaleOutRequests++
 		state.ClusterScaleInRequests = 0
-		if state.ClusterScaleOutRequests == clusterScaling.ScalingThreshold {
+		if state.ClusterScaleOutRequests == config.ClusterScaling.ScalingThreshold {
 			state.ClusterScaleOutRequests = 0
 			logging.Debug("core/cluster_scaling: scale out requests %v has reached threshold %v",
-				state.ClusterScaleInRequests, clusterScaling.ScalingThreshold)
-			return true
+				state.ClusterScaleInRequests, config.ClusterScaling.ScalingThreshold)
+			scale = true
 		}
 
 		logging.Debug("core/cluster_scaling: scale out requests %v has not been reached threshold %v",
-			state.ClusterScaleOutRequests, clusterScaling.ScalingThreshold)
+			state.ClusterScaleOutRequests, config.ClusterScaling.ScalingThreshold)
 
 	default:
 		state.ClusterScaleInRequests = 0
 		state.ClusterScaleOutRequests = 0
 	}
-	return
+
+	// One way or another we have updated our internal state, therefore this needs
+	// to be written to our persistant state store.
+	if err := config.ConsulClient.WriteState(config, state); err != nil {
+		logging.Error("core:cluster_scaling: unable to update cluster scaling state to persistant store: %v", err)
+		scale = false
+	}
+
+	return scale
 }

--- a/replicator/cluster_scaling_test.go
+++ b/replicator/cluster_scaling_test.go
@@ -5,38 +5,48 @@ import (
 
 	"github.com/elsevier-core-engineering/replicator/client"
 	"github.com/elsevier-core-engineering/replicator/replicator/structs"
+	"github.com/hashicorp/consul/testutil"
 )
 
 func TestClusterScaling_scalingThreshold(t *testing.T) {
 
-	cluster := &structs.ClusterScaling{}
+	srv1 := testutil.NewTestServer(t)
+	defer srv1.Stop()
+
+	consul, _ := client.NewConsulClient(srv1.HTTPAddr, "")
+
+	config := &structs.Config{
+		ConsulClient:      consul,
+		ConsulKeyLocation: "replicator/config",
+		ClusterScaling:    &structs.ClusterScaling{},
+	}
 	state := &structs.State{}
-	cluster.ScalingThreshold = 3
+	config.ClusterScaling.ScalingThreshold = 3
 
 	// Check ScaleOut scenarios.
 	state.ClusterScaleOutRequests = 2
-	if !checkScalingThreshold(state, client.ScalingDirectionOut, cluster) {
+	if !checkScalingThreshold(state, client.ScalingDirectionOut, config) {
 		t.Fatal("expected ClusterScaleOut to answer true but got false")
 	}
 
 	state.ClusterScaleOutRequests = 1
-	if checkScalingThreshold(state, client.ScalingDirectionOut, cluster) {
+	if checkScalingThreshold(state, client.ScalingDirectionOut, config) {
 		t.Fatal("expected ClusterScaleOut to answer false but got true")
 	}
 
 	// Check ScaleIn scenarios.
 	state.ClusterScaleInRequests = 2
-	if !checkScalingThreshold(state, client.ScalingDirectionIn, cluster) {
+	if !checkScalingThreshold(state, client.ScalingDirectionIn, config) {
 		t.Fatal("expected ClusterScaleIn to answer true but got false")
 	}
 
 	state.ClusterScaleInRequests = 1
-	if checkScalingThreshold(state, client.ScalingDirectionIn, cluster) {
+	if checkScalingThreshold(state, client.ScalingDirectionIn, config) {
 		t.Fatal("expected ClusterScaleIn to answer false but got true")
 	}
 
 	// Check the default return and state setting.
-	if checkScalingThreshold(state, client.ScalingDirectionNone, cluster) {
+	if checkScalingThreshold(state, client.ScalingDirectionNone, config) {
 		t.Fatal("expected ClusterScalingNone to answer false but got true")
 	}
 

--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -158,7 +158,7 @@ func (r *Runner) clusterScaling(done chan bool, state *structs.State) {
 	}
 
 	if clusterCapacity.ScalingDirection == client.ScalingDirectionOut &&
-		checkScalingThreshold(state, clusterCapacity.ScalingDirection, r.config.ClusterScaling) {
+		checkScalingThreshold(state, clusterCapacity.ScalingDirection, r.config) {
 		// If cluster scaling has been disabled, report but do not initiate a
 		// scaling operation.
 		if !scalingEnabled {
@@ -273,7 +273,7 @@ func (r *Runner) clusterScaling(done chan bool, state *structs.State) {
 	}
 
 	if clusterCapacity.ScalingDirection == client.ScalingDirectionIn &&
-		checkScalingThreshold(state, clusterCapacity.ScalingDirection, r.config.ClusterScaling) {
+		checkScalingThreshold(state, clusterCapacity.ScalingDirection, r.config) {
 		// Attempt to identify the least-allocated node in the worker pool.
 		nodeID, nodeIP := nomadClient.LeastAllocatedNode(clusterCapacity, state)
 		if nodeIP != "" && nodeID != "" {


### PR DESCRIPTION
The introduction of ScalingThreshold meant we had additional
state fields. When these in-memory ints were getting updated, the
change was not being persisted to Consul. Therefore upon state
read the in-memory values were overwritten with the starting
values.

The checkScalingThreshold function will now finish by writing
update state to the persistent store, meaning evaluations are not
over-written or thrown away.

Closes #134 