### PR TITLE
Reset Failure Count When Exiting Failsafe

### DIFF
--- a/command/failsafe.go
+++ b/command/failsafe.go
@@ -23,12 +23,12 @@ func (c *FailsafeCommand) Help() string {
 	helpText := `
 Usage: replicator failsafe [options]
 
-  Allows an operator to administratively control the failsafe behavior
-  of Replicator. When Replicator enters failsafe mode, all running
-  copies of Replicator will prohibit any scaling operations on the
-  resource in question.
+  Allows an operator to administratively control the failsafe behavior of
+  Replicator. When Replicator places a job or worker pool in failsafe mode, 
+  all running copies of Replicator will prohibit any scaling operations
+  against the resource in question.
 
-  Failsafe mode is intended to stabilize a cluster that has experienced
+  Failsafe mode is intended to stabilize a respource that has experienced
   critical failures while attempting to perform scaling operations.
 
   To exit failsafe mode, an operator must explicitly remove the failsafe
@@ -52,14 +52,15 @@ Usage: replicator failsafe [options]
       it provides a "well-known" IP address for which clients can connect.
 
     -consul-token=<token>
-      The Consul ACL token to use when communicating with an ACL
-      protected Consul cluster.
+      The Consul ACL token to use when communicating with an ACL protected
+      Consul cluster.
 
     -state-path=<key>
-      The Consul Key/Value Store where the state object is stored for the
-      resource which failsafe will be manipulated for. The default base is
-      replicator/config/state; cluster worker pools live at worker/<pool_name>
-      and job group state at jobs/<job_name>/<group_name>.
+      The full Consul Key/Value path where the state object for the resource
+      is stored. By default, Replicator stores all state objects at a common
+      base path, replicator/config/state; within this base context, worker
+      pools state is stored at nodes/<pool_name> and jobs at
+      jobs/<job_name>/<group_name>.
 
   Failsafe Mode Options:
 

--- a/replicator/failsafe.go
+++ b/replicator/failsafe.go
@@ -72,6 +72,10 @@ func SetFailsafeMode(state *structs.ScalingState, config *structs.Config,
 		}
 
 	case false:
+		// Reset the failure count to allow Replicator to start with a clean
+		// slate during the next evaluation.
+		state.FailureCount = 0
+
 		if !state.FailsafeAdmin {
 			logging.Info("core/failsafe: disabling failsafe mode for %v %v",
 				message.ResourceType, message.ResourceID)

--- a/replicator/failsafe_test.go
+++ b/replicator/failsafe_test.go
@@ -84,6 +84,8 @@ func TestFailsafe_SetFailsafeMode(t *testing.T) {
 
 	// Setup our state object and set helper fields.
 	state := &structs.ScalingState{}
+	state.FailureCount = 3
+	state.FailsafeMode = true
 	state.ResourceType = ClusterType
 	state.ResourceName = workerPool.Name
 	state.StatePath = "replicator/config/state/nodes/" + workerPool.Name
@@ -95,12 +97,18 @@ func TestFailsafe_SetFailsafeMode(t *testing.T) {
 		ResourceType: state.ResourceType,
 	}
 
-	// Verify requesting to disable failsafe mode works.
+	// Verify a request to disable failsafe mode works.
 	enabled := false
 	SetFailsafeMode(state, c, enabled, message)
 
 	if state.FailsafeMode != enabled {
 		t.Fatalf("expected FailsafeMode to be %v but got %v", enabled,
 			state.FailsafeMode)
+	}
+
+	// Verify the failure count is reset when the failsafe circuit
+	// breaker is reset.
+	if state.FailureCount != 0 {
+		t.Fatalf("expected failure count to %v but got %v", 0, state.FailureCount)
 	}
 }


### PR DESCRIPTION
This commit ensures the failure count of a scalable resource is
reset when an operator resets the failsafe circuit breaker.

This resolves a bug that results in the failsafe circuit breaker
always being tripped for a scalable resource at the next scaling
evaluation, if the circuit breaker was tripped automatically -
that is, not by an operator.

A test has been added to prove the fix. Also includes small
fixes in the `failsafe` command help verbage.

Closes #188.