### PR TITLE
Improve accuracy and detail of cluster_scaling telemetry metrics.

### DIFF
--- a/client/aws.go
+++ b/client/aws.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	metrics "github.com/armon/go-metrics"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -115,7 +114,6 @@ func ScaleOutCluster(asgName string, nodeCount int, svc *autoscaling.AutoScaling
 				if len(asg.AutoScalingGroups[0].Instances) == int(newDesiredCapacity) {
 					logging.Info("client/aws: verified the autoscaling operation has " +
 						"completed successfully")
-					metrics.IncrCounter([]string{"cluster", "aws", "scale_out"}, 1)
 					return nil
 				}
 			}
@@ -197,7 +195,6 @@ func ScaleInCluster(asgName, instanceIP string, svc *autoscaling.AutoScaling) er
 		return fmt.Errorf("an error occurred terminating instance %v", instanceID)
 	}
 
-	metrics.IncrCounter([]string{"cluster", "aws", "scale_in"}, 1)
 	return nil
 }
 
@@ -399,8 +396,6 @@ func TerminateInstance(instanceID, region string) error {
 			if *resp.InstanceStatuses[0].InstanceState.Name == "terminated" {
 				logging.Info("client/aws: successful termination of %s confirmed",
 					instanceID)
-
-				metrics.IncrCounter([]string{"cluster", "aws", "instance_terminations"}, 1)
 
 				return nil
 			}


### PR DESCRIPTION
This change removes some fairly useless aws metrics and adds finer
detail, including the worker pool name and success/failure result
when cluster scaling activites are actioned.