### PR TITLE
Improve Cluster Scaling Logging In INFO Log Level

### DIFF
--- a/client/nomad_test.go
+++ b/client/nomad_test.go
@@ -110,16 +110,16 @@ func TestNomad_MostUtilizedResource(t *testing.T) {
 	client.MostUtilizedResource(diskCap)
 	client.MostUtilizedResource(zeroCap)
 
-	if cpuCap.ScalingMetric != ScalingMetricProcessor {
+	if cpuCap.ScalingMetric.Type != ScalingMetricProcessor {
 		t.Fatalf("expected scaling metric %v but got %v", ScalingMetricProcessor, cpuCap.ScalingMetric)
 	}
-	if memCap.ScalingMetric != ScalingMetricMemory {
+	if memCap.ScalingMetric.Type != ScalingMetricMemory {
 		t.Fatalf("expected scaling metric %v but got %v", ScalingMetricMemory, memCap.ScalingMetric)
 	}
-	if diskCap.ScalingMetric != ScalingMetricDisk {
+	if diskCap.ScalingMetric.Type != ScalingMetricDisk {
 		t.Fatalf("expected scaling metric %v but got %v", ScalingMetricDisk, diskCap.ScalingMetric)
 	}
-	if zeroCap.ScalingMetric != ScalingMetricNone {
+	if zeroCap.ScalingMetric.Type != ScalingMetricNone {
 		t.Fatalf("expected scaling metric %v but got %v", ScalingMetricNone, zeroCap.ScalingMetric)
 	}
 }
@@ -160,8 +160,10 @@ func TestNomad_MaxAllowedClusterUtilization(t *testing.T) {
 	scaleIn := true
 
 	cap := &structs.ClusterCapacity{
-		ScalingMetric: ScalingMetricMemory,
-		NodeCount:     4,
+		ScalingMetric: structs.ScalingMetric{
+			Type: ScalingMetricMemory,
+		},
+		NodeCount: 4,
 		TaskAllocation: structs.AllocationResources{
 			MemoryMB: 2048,
 			CPUMHz:   2400,
@@ -173,7 +175,7 @@ func TestNomad_MaxAllowedClusterUtilization(t *testing.T) {
 	}
 	memCap := MaxAllowedClusterUtilization(cap, nodeFaultTolerance, scaleIn)
 
-	cap.ScalingMetric = ScalingMetricProcessor
+	cap.ScalingMetric.Type = ScalingMetricProcessor
 	cpuCap := MaxAllowedClusterUtilization(cap, nodeFaultTolerance, scaleIn)
 
 	if memCap != 2048 {

--- a/replicator/structs/nomad.go
+++ b/replicator/structs/nomad.go
@@ -83,7 +83,7 @@ type ClusterCapacity struct {
 	// ScalingMetric indicates the most-utilized allocation resource across the
 	// cluster. The most-utilized resource is prioritized when making scaling
 	// decisions like identifying the least-allocated worker node.
-	ScalingMetric string
+	ScalingMetric ScalingMetric
 
 	// MaxAllowedUtilization represents the max allowed cluster utilization after
 	// considering node fault-tolerance and task group scaling overhead.
@@ -146,4 +146,11 @@ type AllocationResources struct {
 	MemoryPercent float64
 	CPUPercent    float64
 	DiskPercent   float64
+}
+
+// ScalingMetric tracks information about the prioritized scaling metric.
+type ScalingMetric struct {
+	Type        string
+	Capacity    int
+	Utilization int
 }


### PR DESCRIPTION
This commit enhances and improves the logging produced by cluster
scaling when Replicator is running at an `INFO` log level.