### PR TITLE
Improve Node Protection Mechanism

### DIFF
--- a/client/nomad.go
+++ b/client/nomad.go
@@ -115,15 +115,15 @@ func (c *nomadClient) MostUtilizedGroupResource(gsp *structs.GroupScalingPolicy)
 // amount of the cluster's most-utilized resource. If Replicator is running as
 // a Nomad job, the worker node running the Replicator leader will be excluded.
 func (c *nomadClient) LeastAllocatedNode(capacity *structs.ClusterCapacity,
-	state *structs.ScalingState) (nodeID, nodeIP string) {
+	protectedNode string) (nodeID, nodeIP string) {
 	var lowest float64
 
 	for _, alloc := range capacity.NodeAllocations {
 		// If we've encountered a protected worker pool node, exclude it from
 		// least-allocated node discovery.
-		if alloc.NodeID == state.ProtectedNode {
+		if alloc.NodeID == protectedNode {
 			logging.Debug("client/nomad: Node %v will be excluded when calculating "+
-				"eligible worker pool nodes to be removed", state.ProtectedNode)
+				"eligible worker pool nodes to be removed", protectedNode)
 			continue
 		}
 

--- a/replicator/cluster_scaling.go
+++ b/replicator/cluster_scaling.go
@@ -205,7 +205,8 @@ func (r *Runner) workerPoolScaling(poolName string,
 
 	if poolCapacity.ScalingDirection == client.ScalingDirectionIn {
 		// Identify the least allocated node in the worker pool.
-		nodeID, nodeIP := nomadClient.LeastAllocatedNode(poolCapacity, poolState)
+		nodeID, nodeIP := nomadClient.LeastAllocatedNode(poolCapacity,
+			workerPool.ProtectedNode)
 		if nodeIP == "" || nodeID == "" {
 			logging.Error("core/cluster_scaling: unable to identify the least "+
 				"allocated node in worker pool %v", workerPool.Name)

--- a/replicator/node_protection.go
+++ b/replicator/node_protection.go
@@ -1,0 +1,44 @@
+package replicator
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/elsevier-core-engineering/replicator/logging"
+	"github.com/elsevier-core-engineering/replicator/replicator/structs"
+)
+
+func (r *Runner) nodeProtectionCheck(nodeReg *structs.NodeRegistry) error {
+	// Check our runtime environment to see if we have a Nomad allocation.
+	allocID := os.Getenv("NOMAD_ALLOC_ID")
+
+	// If we're not running as a Nomad job, return immediately.
+	if len(allocID) == 0 {
+		return nil
+	}
+
+	// Perform a reverse lookup to get the Nomad node hosting our allocation.
+	host, err := r.config.NomadClient.NodeReverseLookup(allocID)
+	if err != nil || len(host) == 0 {
+		return fmt.Errorf("Replicator is running as a Nomad job but we are "+
+			"unable to determine the node hosting our allocation %v: %v",
+			allocID, err)
+	}
+
+	nodeReg.Lock.Lock()
+	// Ask the node registry to give us the worker pool for the node hosting
+	// our allocation.
+	pool, ok := nodeReg.RegisteredNodes[host]
+	if !ok {
+		return fmt.Errorf("running as a Nomad job but unable to determine the "+
+			"worker pool for our host node %v", host)
+	}
+
+	// Register the node as protected in the node registry.
+	logging.Debug("core/node_protection: registering node %v from worker "+
+		"pool %v as protected", host, pool)
+	nodeReg.WorkerPools[pool].ProtectedNode = host
+	nodeReg.Lock.Unlock()
+
+	return nil
+}

--- a/replicator/node_protection.go
+++ b/replicator/node_protection.go
@@ -35,9 +35,11 @@ func (r *Runner) nodeProtectionCheck(nodeReg *structs.NodeRegistry) error {
 	}
 
 	// Register the node as protected in the node registry.
-	logging.Debug("core/node_protection: registering node %v from worker "+
-		"pool %v as protected", host, pool)
-	nodeReg.WorkerPools[pool].ProtectedNode = host
+	if nodeReg.WorkerPools[pool].ProtectedNode != host {
+		logging.Debug("core/node_protection: registering node %v from worker "+
+			"pool %v as protected", host, pool)
+		nodeReg.WorkerPools[pool].ProtectedNode = host
+	}
 	nodeReg.Lock.Unlock()
 
 	return nil

--- a/replicator/structs/nomad.go
+++ b/replicator/structs/nomad.go
@@ -51,7 +51,7 @@ type NomadClient interface {
 
 	// LeastAllocatedNode determines which worker pool node is consuming the
 	// least amount of the cluster's most-utilized resource.
-	LeastAllocatedNode(*ClusterCapacity, *ScalingState) (string, string)
+	LeastAllocatedNode(*ClusterCapacity, string) (string, string)
 
 	// NodeReverseLookup provides a method to get the ID of the worker pool node
 	// running a given allocation.

--- a/replicator/structs/state.go
+++ b/replicator/structs/state.go
@@ -36,11 +36,6 @@ type ScalingState struct {
 	// access to the object.
 	Lock sync.RWMutex `json:"-"`
 
-	// ProtectedNode represents the Nomad agent node on which the Replicator
-	// leader is running. This node will be excluded when identifying an eligible
-	// node for termination during scaling actions.
-	ProtectedNode string `json:"protected_node"`
-
 	// ResourceName provides a shortcut method for identifying the resource
 	// this state is associated with.
 	ResourceName string `json:"resource_name"`

--- a/version/version.go
+++ b/version/version.go
@@ -3,12 +3,12 @@ package version
 import "fmt"
 
 // Version is the main version number that is being run at the moment.
-const Version = "1.0.1"
+const Version = "1.0.2"
 
 // VersionPrerelease is a pre-release marker for the version. If this is ""
 // (empty string) then it means that it is a final release. Otherwise, this is
 // a pre-release such as "dev" (in development), "beta", "rc1", etc.
-const VersionPrerelease = ""
+const VersionPrerelease = "dev"
 
 // Get returns a human readable version of replicator.
 func Get() string {


### PR DESCRIPTION
If Replicator wins the leader election, it automatically determines
if it is running as a Nomad job and attempts to protect the worker
pool node hosting its allocation.

If a node is marked as protected, Replicator will consider it
ineligible when identifying a node for scale in.

This commit improves the node protection mechanism, provides some
organization and ensures the `LeastAllocatedNode` method in the
`client/nomad` package actually uses this value during evaluation.

Closes #197.