### PR TITLE
Nomad job_scaling logic fixes

### DIFF
--- a/client/nomad.go
+++ b/client/nomad.go
@@ -247,6 +247,9 @@ func (c *nomadClient) EvaluateJobScaling(jobName string, jobScalingPolicies []*s
 		c.GetJobAllocations(allocs, gsp)
 		c.MostUtilizedGroupResource(gsp)
 
+		// Reset the direction
+		gsp.ScaleDirection = ScalingDirectionNone
+
 		switch gsp.ScalingMetric {
 		case ScalingMetricProcessor:
 			if gsp.Tasks.Resources.CPUPercent > gsp.ScaleOutCPU {

--- a/client/nomad.go
+++ b/client/nomad.go
@@ -217,6 +217,9 @@ func (c *nomadClient) GetTaskGroupResources(jobName string, groupPolicy *structs
 	if err != nil {
 		return err
 	}
+	// Make sure the values are zeroed
+	groupPolicy.Tasks.Resources.CPUMHz = 0
+	groupPolicy.Tasks.Resources.MemoryMB = 0
 
 	for _, group := range jobs.TaskGroups {
 		for _, task := range group.Tasks {

--- a/replicator/structs/nomad.go
+++ b/replicator/structs/nomad.go
@@ -32,7 +32,7 @@ type NomadClient interface {
 
 	// GetAllocationStats discovers the resources consumed by a particular Nomad
 	// allocation.
-	GetAllocationStats(*nomad.Allocation, *GroupScalingPolicy)
+	GetAllocationStats(*nomad.Allocation, *GroupScalingPolicy) (float64, float64)
 
 	// GetJobAllocations identifies all allocations for an active job.
 	GetJobAllocations([]*nomad.AllocationListStub, *GroupScalingPolicy)


### PR DESCRIPTION
We recently evaluated replicator for our stack and found a couple of bugs making it unusable for us.
This is the way we fixed them.

- When a scaling action is set, it stays until another scaling action is set, it is never reset when the values are within a healthy threshold. Solved by setting `gsp.ScaleDirection` to `ScalingDirectionNone` before evaluating.

- When calculating reserved resources the `groupPolicy.Tasks.Resources.CPUMHz` and `groupPolicy.Tasks.Resources.MemoryMB` accumulate without being reset between cycles, making the metric approach 0% over time. Fixed this by setting them to 0 before every evaluation.

- Metric data for all jobs in a group are collected, but they overwrite each other, so only the last processed is used for the evaluation. Fixed this by making the collector return values and then average them.

Thanks to @heimweh and @chronitis for helping me.