### PR TITLE
Docs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Until Vault integration is added, the instance pool which is capable of running 
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "Authorize AutoScaling Actions",
+      "Sid": "AuthorizeAutoScalingActions",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
@@ -152,7 +152,7 @@ Until Vault integration is added, the instance pool which is capable of running 
       "Resource": "*"
     },
     {
-      "Sid": "Authorize EC2 Actions",
+      "Sid": "AuthorizeEC2Actions",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/command/init.go
+++ b/command/init.go
@@ -120,8 +120,8 @@ var defaultClusterScalingDocument = strings.TrimSpace(`
 meta {
   "replicator_cool_down"            = 400
   "replicator_enabled"              = true
-  "replicator_max_size"             = 10
-  "replicator_min_size"             = 5
+  "replicator_max"                  = 10
+  "replicator_min"                  = 5
   "replicator_node_fault_tolerance" = 1
   "replicator_notification_uid"     = "REP2"
   "replicator_region"               = "us-east-1"


### PR DESCRIPTION
- IAM policy doesn't allow whitespaces in Sid
- Init was generating cluster old scaling meta tags