### PR TITLE
Remove Explicit Cluster Scaling Thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 NEW FEATURES:
 
-* **Scaling Provider**: Replicator now implements a cloud provider model to support cluster scaling operations across multiple cloud providers. [GH-203] 
+* **Scaling Provider**: Replicator now implements a cloud provider model to support cluster scaling operations across multiple cloud providers. [GH-203]
 
 BUG FIXES:
 
 * Filter out Nomad jobs that do not include an `update` stanza to prevent segmentation violations when attempting to verify job scaling activities. Thank you to @burdandrei. [GH-209]
 * Update init command to generate correct cluster_scaling meta tags. Thank you to @burdandrei. [GH-210]
+
+IMPROVEMENTS:
+
+* Remove explicit min/max thresholds for cluster scaling in favor of dynamic threshold discovery in the cloud provider.
 
 ## 1.0.3 (22 September 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@ IMPROVEMENTS:
 
 * Remove explicit min/max thresholds for cluster scaling in favor of dynamic threshold discovery in the cloud provider.
 
-IMPROVEMENTS:
-
-* Remove explicit min/max thresholds for cluster scaling in favor of dynamic threshold discovery in the cloud provider.
-
 ## 1.0.3 (22 September 2017)
 
 BUG FIXES:

--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ An example Nomad client configuration that can be used to enable autoscaling on 
         "meta": {
             "replicator_cooldown": 300,
             "replicator_enabled": "true",
-            "replicator_max": 3,
-            "replicator_min": 2,
             "replicator_node_fault_tolerance": 1,
             "replicator_notification_uid": "REP2",
             "replicator_region": "us-east-1",

--- a/client/node_discovery.go
+++ b/client/node_discovery.go
@@ -138,8 +138,6 @@ func ProcessNodeConfig(node *nomad.Node) (pool *structs.WorkerPool, err error) {
 	// Required meta configuration keys.
 	requiredKeys := []string{
 		"replicator_enabled",
-		"replicator_max",
-		"replicator_min",
 		"replicator_notification_uid",
 		"replicator_provider",
 		"replicator_region",
@@ -221,8 +219,6 @@ func Register(node *nomad.Node, workerPool *structs.WorkerPool,
 		if changed {
 			logging.Debug("client/node_discovery: worker pool configuration has " +
 				"changed, updating.")
-			existingPool.Max = workerPool.Max
-			existingPool.Min = workerPool.Min
 			existingPool.Region = workerPool.Region
 			existingPool.Cooldown = workerPool.Cooldown
 			existingPool.RetryThreshold = workerPool.RetryThreshold

--- a/client/node_discovery_test.go
+++ b/client/node_discovery_test.go
@@ -166,8 +166,6 @@ func TestNodeDiscovery_Deregister(t *testing.T) {
 	expectedRegistry.WorkerPools["example-group"] = &structs.WorkerPool{
 		Cooldown:         300,
 		FaultTolerance:   1,
-		Max:              3,
-		Min:              1,
 		NotificationUID:  "Test01",
 		Region:           "us-east-1",
 		RetryThreshold:   3,
@@ -241,8 +239,6 @@ func TestNodeDiscovery_RegisterNode(t *testing.T) {
 	expected.WorkerPools["example-group"] = &structs.WorkerPool{
 		Cooldown:         300,
 		FaultTolerance:   1,
-		Max:              3,
-		Min:              1,
 		NotificationUID:  "Test01",
 		Region:           "us-east-1",
 		RetryThreshold:   3,
@@ -350,7 +346,6 @@ func TestNodeDiscovery_RegisterNode(t *testing.T) {
 	}
 
 	// Update expected state.
-	expected.WorkerPools["example-group"].Max = 5
 	workerPoolNodes = expected.WorkerPools["example-group"].Nodes
 	workerPoolNode := workerPoolNodes["ec282e52-4fb6-5950-ef5b-257fced6313c"]
 	workerPoolNode.Meta["replicator_max"] = "5"

--- a/cloud/aws/aws_cloud_provider.go
+++ b/cloud/aws/aws_cloud_provider.go
@@ -315,8 +315,7 @@ func (sp *AwsScalingProvider) SafetyCheck(workerPool *structs.WorkerPool) bool {
 		// If scaling in would violate the ASG min count, fail the safety check.
 		if desiredCap-1 < minSize {
 			logging.Debug("cloud/aws: cluster scale-in operation would violate the "+
-				"worker pool ASG min count (desired: %v, min: %v)",
-				desiredCap-1, minSize)
+				"worker pool ASG min count (desired: %v, min: %v)", desiredCap-1, minSize)
 			return false
 		}
 	}
@@ -325,8 +324,7 @@ func (sp *AwsScalingProvider) SafetyCheck(workerPool *structs.WorkerPool) bool {
 		// If scaling out would violate the ASG max count, fail the safety check.
 		if desiredCap+1 > maxSize {
 			logging.Debug("cloud/aws: cluster scale-out operation would violate "+
-				"the worker pool ASG max count (desired: %v, max: %v)",
-				desiredCap+1, maxSize)
+				"the worker pool ASG max count (desired: %v, max: %v)", desiredCap+1, maxSize)
 			return false
 		}
 	}

--- a/cloud/aws/aws_cloud_provider.go
+++ b/cloud/aws/aws_cloud_provider.go
@@ -315,7 +315,8 @@ func (sp *AwsScalingProvider) SafetyCheck(workerPool *structs.WorkerPool) bool {
 		// If scaling in would violate the ASG min count, fail the safety check.
 		if desiredCap-1 < minSize {
 			logging.Debug("cloud/aws: cluster scale-in operation would violate the "+
-				"worker pool ASG min count: %v", minSize)
+				"worker pool ASG min count (desired: %v, min: %v)",
+				desiredCap-1, minSize)
 			return false
 		}
 	}
@@ -324,7 +325,8 @@ func (sp *AwsScalingProvider) SafetyCheck(workerPool *structs.WorkerPool) bool {
 		// If scaling out would violate the ASG max count, fail the safety check.
 		if desiredCap+1 > maxSize {
 			logging.Debug("cloud/aws: cluster scale-out operation would violate "+
-				"the worker pool ASG max count: %v", maxSize)
+				"the worker pool ASG max count (desired: %v, max: %v)",
+				desiredCap+1, maxSize)
 			return false
 		}
 	}

--- a/command/init.go
+++ b/command/init.go
@@ -120,8 +120,6 @@ var defaultClusterScalingDocument = strings.TrimSpace(`
 meta {
   "replicator_cool_down"            = 400
   "replicator_enabled"              = true
-  "replicator_max"                  = 10
-  "replicator_min"                  = 5
   "replicator_node_fault_tolerance" = 1
   "replicator_notification_uid"     = "REP2"
   "replicator_region"               = "us-east-1"

--- a/replicator/structs/node_discovery.go
+++ b/replicator/structs/node_discovery.go
@@ -46,8 +46,6 @@ type NodeRegistry struct {
 type WorkerPool struct {
 	Cooldown          int                    `mapstructure:"replicator_cooldown"`
 	FaultTolerance    int                    `mapstructure:"replicator_node_fault_tolerance"`
-	Max               int                    `mapstructure:"replicator_max"`
-	Min               int                    `mapstructure:"replicator_min"`
 	Name              string                 `mapstructure:"replicator_worker_pool"`
 	NodeRegistrations map[string]time.Time   `hash:"ignore"`
 	Nodes             map[string]*nomad.Node `hash:"ignore"`


### PR DESCRIPTION
This commit removes the explicit min/max threshold values for worker
pools. The cloud provider is now solely responsible for dynamically
determining the min/max thresholds from the underlying scaling group.

If the cloud provider safety check determines a scaling operation
would violate either the min or max thresholds, the scaling event
will be denied.

Closes #205