### PR TITLE
job-name-id-missmatch-fix

### DIFF
--- a/client/job_scaling_policies.go
+++ b/client/job_scaling_policies.go
@@ -44,9 +44,9 @@ func (c *nomadClient) JobWatcher(jobScalingPolicies *structs.JobScalingPolicies)
 			// policy struct.
 			switch job.Status {
 			case StateRunning:
-				go c.jobScalingPolicyProcessor(job.Name, jobScalingPolicies)
+				go c.jobScalingPolicyProcessor(job.ID, jobScalingPolicies)
 			case StateDead:
-				go RemoveJobScalingPolicy(job.Name, jobScalingPolicies)
+				go RemoveJobScalingPolicy(job.ID, jobScalingPolicies)
 			default:
 				continue
 			}


### PR DESCRIPTION
Fix state if Job ID and Job Name are not the same, and to function that had to receive Job ID Job Name was passed
