### PR TITLE
Use `AllowStale: true` in all JobScaling actives where its safe.

### DIFF
--- a/client/job_scaling.go
+++ b/client/job_scaling.go
@@ -23,7 +23,7 @@ func (c *nomadClient) JobGroupScale(jobName string, group *structs.GroupScalingP
 
 	// In order to scale the job, we need information on the current status of the
 	// running job from Nomad.
-	jobResp, _, err := c.nomad.Jobs().Info(jobName, &nomad.QueryOptions{})
+	jobResp, _, err := c.nomad.Jobs().Info(jobName, &nomad.QueryOptions{AllowStale: true})
 
 	if err != nil {
 		logging.Error("client/job_scaling: unable to determine job info of %v: %v", jobName, err)

--- a/client/job_scaling.go
+++ b/client/job_scaling.go
@@ -23,7 +23,7 @@ func (c *nomadClient) JobGroupScale(jobName string, group *structs.GroupScalingP
 
 	// In order to scale the job, we need information on the current status of the
 	// running job from Nomad.
-	jobResp, _, err := c.nomad.Jobs().Info(jobName, &nomad.QueryOptions{AllowStale: true})
+	jobResp, _, err := c.nomad.Jobs().Info(jobName, c.queryOptions())
 
 	if err != nil {
 		logging.Error("client/job_scaling: unable to determine job info of %v: %v", jobName, err)
@@ -173,7 +173,7 @@ func (c *nomadClient) getDeploymentID(evalID string) (depID string, err error) {
 // in the process of a deployment.
 func (c *nomadClient) IsJobInDeployment(jobName string) (isRunning bool) {
 
-	resp, _, err := c.nomad.Jobs().LatestDeployment(jobName, nil)
+	resp, _, err := c.nomad.Jobs().LatestDeployment(jobName, c.queryOptions())
 
 	if err != nil {
 		logging.Error("client/job_scaling: unable to list Nomad deployments: %v", err)

--- a/client/job_scaling_policies.go
+++ b/client/job_scaling_policies.go
@@ -66,7 +66,7 @@ func (c *nomadClient) JobWatcher(jobScalingPolicies *structs.JobScalingPolicies)
 // their meta paramerters scaling policy status.
 func (c *nomadClient) jobScalingPolicyProcessor(jobID string, scaling *structs.JobScalingPolicies) {
 
-	jobInfo, _, err := c.nomad.Jobs().Info(jobID, &nomad.QueryOptions{})
+	jobInfo, _, err := c.nomad.Jobs().Info(jobID, &nomad.QueryOptions{AllowStale: true})
 	if err != nil {
 		logging.Error("client/job_scaling_policies: unable to call Nomad job info: %v", err)
 	}

--- a/client/job_scaling_policies.go
+++ b/client/job_scaling_policies.go
@@ -66,7 +66,7 @@ func (c *nomadClient) JobWatcher(jobScalingPolicies *structs.JobScalingPolicies)
 // their meta paramerters scaling policy status.
 func (c *nomadClient) jobScalingPolicyProcessor(jobID string, scaling *structs.JobScalingPolicies) {
 
-	jobInfo, _, err := c.nomad.Jobs().Info(jobID, &nomad.QueryOptions{AllowStale: true})
+	jobInfo, _, err := c.nomad.Jobs().Info(jobID, c.queryOptions())
 	if err != nil {
 		logging.Error("client/job_scaling_policies: unable to call Nomad job info: %v", err)
 	}

--- a/client/nomad.go
+++ b/client/nomad.go
@@ -54,7 +54,7 @@ func NewNomadClient(addr string) (structs.NomadClient, error) {
 // NodeReverseLookup provides a method to get the ID of the worker pool node
 // running a given allocation.
 func (c *nomadClient) NodeReverseLookup(allocID string) (node string, err error) {
-	resp, _, err := c.nomad.Allocations().Info(allocID, &nomad.QueryOptions{})
+	resp, _, err := c.nomad.Allocations().Info(allocID, &nomad.QueryOptions{AllowStale: true})
 	if err != nil {
 		return
 	}
@@ -209,7 +209,7 @@ func (c *nomadClient) DrainNode(nodeID string) (err error) {
 // GetTaskGroupResources finds the defined resource requirements for a
 // given Job.
 func (c *nomadClient) GetTaskGroupResources(jobName string, groupPolicy *structs.GroupScalingPolicy) error {
-	jobs, _, err := c.nomad.Jobs().Info(jobName, &nomad.QueryOptions{})
+	jobs, _, err := c.nomad.Jobs().Info(jobName, &nomad.QueryOptions{AllowStale: true})
 
 	if err != nil {
 		return err
@@ -236,7 +236,7 @@ func (c *nomadClient) EvaluateJobScaling(jobName string, jobScalingPolicies []*s
 			return
 		}
 
-		allocs, _, err := c.nomad.Jobs().Allocations(jobName, false, &nomad.QueryOptions{})
+		allocs, _, err := c.nomad.Jobs().Allocations(jobName, false, &nomad.QueryOptions{AllowStale: true})
 		if err != nil {
 			return err
 		}
@@ -276,7 +276,7 @@ func (c *nomadClient) GetJobAllocations(allocs []*nomad.AllocationListStub, gsp 
 		if (allocationStub.ClientStatus == nomadStructs.AllocClientStatusRunning) &&
 			(allocationStub.DesiredStatus == nomadStructs.AllocDesiredStatusRun) {
 
-			if alloc, _, err := c.nomad.Allocations().Info(allocationStub.ID, &nomad.QueryOptions{}); err == nil && alloc != nil {
+			if alloc, _, err := c.nomad.Allocations().Info(allocationStub.ID, &nomad.QueryOptions{AllowStale: true}); err == nil && alloc != nil {
 				cpuPercent, memPercent := c.GetAllocationStats(alloc, gsp)
 				cpuPercentAll += cpuPercent
 				memPercentAll += memPercent
@@ -352,7 +352,7 @@ func (c *nomadClient) VerifyNodeHealth(nodeIP string) (healthy bool) {
 // GetAllocationStats discovers the resources consumed by a particular Nomad
 // allocation.
 func (c *nomadClient) GetAllocationStats(allocation *nomad.Allocation, scalingPolicy *structs.GroupScalingPolicy) (float64, float64) {
-	stats, err := c.nomad.Allocations().Stats(allocation, &nomad.QueryOptions{})
+	stats, err := c.nomad.Allocations().Stats(allocation, &nomad.QueryOptions{AllowStale: true})
 	if err != nil {
 		logging.Error("client/nomad: failed to retrieve allocation statistics from client %v: %v\n", allocation.NodeID, err)
 		return 0, 0

--- a/client/nomad.go
+++ b/client/nomad.go
@@ -51,10 +51,16 @@ func NewNomadClient(addr string) (structs.NomadClient, error) {
 	return &nomadClient{nomad: c}, nil
 }
 
+// queryOptions sets Replicators default QueryOptions for making GET calls to
+// the API.
+func (c *nomadClient) queryOptions() (queryOptions *nomad.QueryOptions) {
+	return &nomad.QueryOptions{AllowStale: true}
+}
+
 // NodeReverseLookup provides a method to get the ID of the worker pool node
 // running a given allocation.
 func (c *nomadClient) NodeReverseLookup(allocID string) (node string, err error) {
-	resp, _, err := c.nomad.Allocations().Info(allocID, &nomad.QueryOptions{AllowStale: true})
+	resp, _, err := c.nomad.Allocations().Info(allocID, c.queryOptions())
 	if err != nil {
 		return
 	}
@@ -209,7 +215,7 @@ func (c *nomadClient) DrainNode(nodeID string) (err error) {
 // GetTaskGroupResources finds the defined resource requirements for a
 // given Job.
 func (c *nomadClient) GetTaskGroupResources(jobName string, groupPolicy *structs.GroupScalingPolicy) error {
-	jobs, _, err := c.nomad.Jobs().Info(jobName, &nomad.QueryOptions{AllowStale: true})
+	jobs, _, err := c.nomad.Jobs().Info(jobName, c.queryOptions())
 
 	if err != nil {
 		return err
@@ -236,7 +242,7 @@ func (c *nomadClient) EvaluateJobScaling(jobName string, jobScalingPolicies []*s
 			return
 		}
 
-		allocs, _, err := c.nomad.Jobs().Allocations(jobName, false, &nomad.QueryOptions{AllowStale: true})
+		allocs, _, err := c.nomad.Jobs().Allocations(jobName, false, c.queryOptions())
 		if err != nil {
 			return err
 		}
@@ -276,7 +282,7 @@ func (c *nomadClient) GetJobAllocations(allocs []*nomad.AllocationListStub, gsp 
 		if (allocationStub.ClientStatus == nomadStructs.AllocClientStatusRunning) &&
 			(allocationStub.DesiredStatus == nomadStructs.AllocDesiredStatusRun) {
 
-			if alloc, _, err := c.nomad.Allocations().Info(allocationStub.ID, &nomad.QueryOptions{AllowStale: true}); err == nil && alloc != nil {
+			if alloc, _, err := c.nomad.Allocations().Info(allocationStub.ID, c.queryOptions()); err == nil && alloc != nil {
 				cpuPercent, memPercent := c.GetAllocationStats(alloc, gsp)
 				cpuPercentAll += cpuPercent
 				memPercentAll += memPercent
@@ -352,7 +358,7 @@ func (c *nomadClient) VerifyNodeHealth(nodeIP string) (healthy bool) {
 // GetAllocationStats discovers the resources consumed by a particular Nomad
 // allocation.
 func (c *nomadClient) GetAllocationStats(allocation *nomad.Allocation, scalingPolicy *structs.GroupScalingPolicy) (float64, float64) {
-	stats, err := c.nomad.Allocations().Stats(allocation, &nomad.QueryOptions{AllowStale: true})
+	stats, err := c.nomad.Allocations().Stats(allocation, c.queryOptions())
 	if err != nil {
 		logging.Error("client/nomad: failed to retrieve allocation statistics from client %v: %v\n", allocation.NodeID, err)
 		return 0, 0


### PR DESCRIPTION
In order to lower the pressure Replicator puts on the Nomad leader
this change introduces adding the QueryOption `AllowStale: true`
to all calls which are safe to do so. The staleness as stated in
the Nomad docs will be less than 50ms, therefore this should not
have any negative impact in the running of Replicator.

Closes #224 