### PR TITLE
Update Travis Script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 dist: trusty
 language: go
 go:
-- 1.9
+- 1.9.x
 before_script:
 - wget https://releases.hashicorp.com/consul/0.7.5/consul_0.7.5_linux_amd64.zip
 - unzip -d $GOPATH/bin consul_0.7.5_linux_amd64.zip
@@ -17,7 +17,7 @@ notifications:
   email: true
 deploy:
   provider: releases
-  go: 1.9
+  go: 1.9.x
   api_key:
     secure: JNEJATrWn9UJqKDG8SBORy4vJaoZmMakI0OYxbR9ScDOVfG+1Vj+EjGggkaW/oNUiPCHIdC1fu8EgYjqI/QOzbODU0rVVYgGNYsDEVamLpa5u6YpG0vyqMOMyPCV+9RxDGPGpWBP6XGo7+oitnxgo32XIPlGKG+NTODHQaOL20ZpmSG2AfyxDYXocHDUJvRZWjqN5GMId6tEqQytvE2PIueiHP6D8/btTtVjbPnPS+Q4wBDkRDzi/eYOd9UzhtswxcTTe8YBV3BnocH+n+uVj775rWSyCRQMqn1EFlK9chsAsdiVb81NtirbSVKWXKdlkyqvNHCHA1SZBZCmycKLQkJkqYFyvIa8W3I7Eoi847O3X+O8/krwPo4HNduswSRFI7ljlAaw74lbtAymGIQBusQ0QKGsBzfAVwju7WF5YwOklP7aR3pwHkQhlLqFS10l43ZPS/TAmEteAQCPNAg6BGuJ7FtkNI2lykElF+eg3DtsBxdQOLkpjM9EvuvJsk6Dgjg3A/JhWIaJBmwtJO+o+OIQyYXz0pyUn1ntJk+VBx81biqdxJMP2e8m392LalqQzucvpiSW/8u4/VGgnrPxMBQjjTEwM4i++PyiUsBpyyEORkJ6i2hGZ4HebrziZ9NjUbeClDozWph/4X0GkgiXQPxaaEz0RHD/bhYr5yMqBPU=
   file:


### PR DESCRIPTION
This commit instructs Travis CI to use the latest available patch within the `Go 1.9.x` release.