### PR TITLE
Implement Concurrency Limits On Scaling Operations

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -135,6 +135,7 @@ func (c *Command) parseFlags() *structs.Config {
 	flags.StringVar(&cliConfig.Nomad, "nomad", "", "")
 	flags.IntVar(&cliConfig.ClusterScalingInterval, "cluster-scaling-interval", 0, "")
 	flags.IntVar(&cliConfig.JobScalingInterval, "job-scaling-interval", 0, "")
+	flags.IntVar(&cliConfig.ScalingConcurrency, "scaling-concurrency", 0, "")
 	flags.BoolVar(&cliConfig.ClusterScalingDisable, "cluster-scaling-disable", false, "")
 	flags.BoolVar(&cliConfig.JobScalingDisable, "job-scaling-disable", false, "")
 

--- a/command/base/config.go
+++ b/command/base/config.go
@@ -28,6 +28,7 @@ func DefaultConfig() *structs.Config {
 		LogLevel:               "INFO",
 		ClusterScalingInterval: 10,
 		JobScalingInterval:     10,
+		ScalingConcurrency:     10,
 
 		Telemetry:    &structs.Telemetry{},
 		Notification: &structs.Notification{},
@@ -45,6 +46,7 @@ func DevConfig() *structs.Config {
 		LogLevel:               "DEBUG",
 		ClusterScalingInterval: 10,
 		JobScalingInterval:     10,
+		ScalingConcurrency:     10,
 
 		Telemetry:    &structs.Telemetry{},
 		Notification: &structs.Notification{},

--- a/command/base/config_parse.go
+++ b/command/base/config_parse.go
@@ -80,6 +80,7 @@ func parseConfig(result *structs.Config, list *ast.ObjectList) error {
 		"notification",
 		"cluster_scaling_disable",
 		"job_scaling_disable",
+		"scaling_concurrency",
 	}
 	if err := checkHCLKeys(list, valid); err != nil {
 		return multierror.Prefix(err, "config:")

--- a/command/base/config_parse_test.go
+++ b/command/base/config_parse_test.go
@@ -18,6 +18,7 @@ func TestConfigParse_LoadConfigFile(t *testing.T) {
     log_level                = "info"
     job_scaling_interval     = 1
     cluster_scaling_interval = 2
+    scaling_concurrency      = 5
 
     telemetry {
       statsd_address = "10.0.0.10:8125"
@@ -44,6 +45,7 @@ func TestConfigParse_LoadConfigFile(t *testing.T) {
 		LogLevel:               "info",
 		JobScalingInterval:     1,
 		ClusterScalingInterval: 2,
+		ScalingConcurrency:     5,
 
 		Telemetry: &structs.Telemetry{
 			StatsdAddress: "10.0.0.10:8125",

--- a/replicator/cluster_scaling.go
+++ b/replicator/cluster_scaling.go
@@ -52,10 +52,6 @@ func (r *Runner) asyncClusterScaling(nodeRegistry *structs.NodeRegistry,
 		pools <- pool
 	}
 
-	// for _, workerPool := range nodeRegistry.WorkerPools {
-	// 	go r.workerPoolScaling(workerPool.Name, nodeRegistry, jobRegistry, &wg)
-	// }
-
 	// Block on all worker pool scaling threads.
 	wg.Wait()
 }

--- a/replicator/cluster_scaling.go
+++ b/replicator/cluster_scaling.go
@@ -23,185 +23,230 @@ func (r *Runner) asyncClusterScaling(nodeRegistry *structs.NodeRegistry,
 	// operations have completed.
 	var wg sync.WaitGroup
 
-	// Register an entry to the wait group for each worker pool.
-	wg.Add(len(nodeRegistry.WorkerPools))
+	// Get the current number of registered worker pools.
+	poolCount := len(nodeRegistry.WorkerPools)
 
-	for _, workerPool := range nodeRegistry.WorkerPools {
-		go r.workerPoolScaling(workerPool.Name, nodeRegistry, jobRegistry, &wg)
+	// Register an entry to the wait group for each worker pool.
+	wg.Add(poolCount)
+
+	// Build a buffered channel to pass our scalable resources to worker threads.
+	pools := make(chan string, poolCount)
+
+	// Calculate the number of worker threads to initiate.
+	maxConcurrency := r.config.ScalingConcurrency
+
+	if poolCount < maxConcurrency {
+		maxConcurrency = poolCount
 	}
+
+	logging.Debug("core/cluster_scaling: initiating %v concurrent scaling "+
+		"threads to process %v worker pools", maxConcurrency, poolCount)
+
+	// Initiate workers to implement worker pool scaling.
+	for w := 1; w <= maxConcurrency; w++ {
+		go r.workerPoolScaling(w, pools, nodeRegistry, jobRegistry, &wg)
+	}
+
+	// Add worker pools to the worker channel.
+	for pool := range nodeRegistry.WorkerPools {
+		pools <- pool
+	}
+
+	// for _, workerPool := range nodeRegistry.WorkerPools {
+	// 	go r.workerPoolScaling(workerPool.Name, nodeRegistry, jobRegistry, &wg)
+	// }
 
 	// Block on all worker pool scaling threads.
 	wg.Wait()
-
-	return
 }
 
 // workerPoolScaling is a thread safe method for scaling an individual
 // worker pool.
-func (r *Runner) workerPoolScaling(poolName string,
+func (r *Runner) workerPoolScaling(id int, pools <-chan string,
 	nodeRegistry *structs.NodeRegistry, jobs *structs.JobScalingPolicies,
 	wg *sync.WaitGroup) {
-
-	// Inform the wait group we have finished our task upon completion.
-	defer wg.Done()
-
-	// Obtain a read-only lock on the Node registry, grab a reference to
-	// our worker pool object and release the lock.
-	nodeRegistry.Lock.RLock()
-	workerPool := nodeRegistry.WorkerPools[poolName]
-	nodeRegistry.Lock.RUnlock()
 
 	// Setup references to clients for Nomad and Consul.
 	nomadClient := r.config.NomadClient
 	consulClient := r.config.ConsulClient
 
-	// Initialize a new disposable capacity object.
-	poolCapacity := &structs.ClusterCapacity{}
+	// Inform the wait group we have finished our task upon completion.
+	// defer wg.Done()
 
-	// Initialize a new scaling state object and set helper fields.
-	workerPool.State = &structs.ScalingState{}
-	workerPool.State.ResourceType = ClusterType
-	workerPool.State.ResourceName = workerPool.Name
-	workerPool.State.StatePath = r.config.ConsulKeyRoot + "/state/nodes/" +
-		workerPool.Name
+	for poolName := range pools {
+		logging.Debug("core/cluster_scaling: scaling thread %v evaluating scaling "+
+			"for worker pool %v", id, poolName)
 
-	// Attempt to load state from persistent storage.
-	consulClient.ReadState(workerPool.State, true)
+		// Obtain a read-only lock on the Node registry, grab a reference to
+		// our worker pool object and release the lock.
+		nodeRegistry.Lock.RLock()
+		workerPool := nodeRegistry.WorkerPools[poolName]
+		nodeRegistry.Lock.RUnlock()
 
-	// Setup a failure message to pass to the failsafe check.
-	msg := &notifier.FailureMessage{
-		AlertUID:     workerPool.NotificationUID,
-		ResourceID:   workerPool.Name,
-		ResourceType: ClusterType,
-	}
+		// Initialize a new disposable capacity object.
+		poolCapacity := &structs.ClusterCapacity{}
 
-	// If the worker pool is in failsafe mode, decline to perform any scaling
-	// evaluation or action.
-	if !FailsafeCheck(workerPool.State, r.config, workerPool.RetryThreshold, msg) {
-		logging.Warning("core/cluster_scaling: worker pool %v is in failsafe "+
-			"mode, no scaling evaluations will be performed", workerPool.Name)
-		return
-	}
+		// Initialize a new scaling state object and set helper fields.
+		workerPool.State = &structs.ScalingState{}
+		workerPool.State.ResourceType = ClusterType
+		workerPool.State.ResourceName = workerPool.Name
+		workerPool.State.StatePath = r.config.ConsulKeyRoot + "/state/nodes/" +
+			workerPool.Name
 
-	// Evaluate worker pool to determine if a scaling operation is required.
-	scale, err := nomadClient.EvaluatePoolScaling(poolCapacity, workerPool, jobs)
-	if err != nil || !scale {
-		logging.Debug("core/cluster_scaling: scaling operation for worker pool %v "+
-			"is either not required or not permitted: %v", workerPool.Name, err)
-		return
-	}
+		// Attempt to load state from persistent storage.
+		consulClient.ReadState(workerPool.State, true)
 
-	// Copy the desired scsaling direction to the state object.
-	workerPool.State.ScalingDirection = poolCapacity.ScalingDirection
-
-	// Attempt to update state tracking information in Consul.
-	if err = consulClient.PersistState(workerPool.State); err != nil {
-		logging.Error("core/cluster_scaling: %v", err)
-	}
-
-	// Call the scaling provider safety check to determine if we should
-	// proceed with scaling evaluation.
-	if scale := workerPool.ScalingProvider.SafetyCheck(workerPool); !scale {
-		logging.Debug("core/cluster_scaling: scaling operation for worker pool %v"+
-			"is not permitted by the scaling provider", workerPool.Name)
-		return
-	}
-
-	// Determine if the scaling cooldown threshold has been met.
-	ok := checkCooldownThreshold(workerPool)
-	if !ok {
-		return
-	}
-
-	// Determine if we've reached the required number of consecutive scaling
-	// requests.
-	ok = checkPoolScalingThreshold(workerPool, r.config)
-	if !ok {
-		return
-	}
-
-	if poolCapacity.ScalingDirection != structs.ScalingDirectionNone {
-		scaleMetric := poolCapacity.ScalingMetric
-
-		logging.Info("core/cluster_scaling: worker pool %v requires a scaling "+
-			"operation: (Direction: %v, Nodes: %v, Metric: %v, Capacity: %v, "+
-			"Utilization: %v, Max Allowed: %v)", workerPool.Name,
-			poolCapacity.ScalingDirection, len(workerPool.Nodes), scaleMetric.Type,
-			scaleMetric.Capacity, scaleMetric.Utilization,
-			poolCapacity.MaxAllowedUtilization)
-	}
-
-	if poolCapacity.ScalingDirection == structs.ScalingDirectionOut {
-		// Initiate cluster scaling operation by calling the scaling provider.
-		err = workerPool.ScalingProvider.Scale(workerPool, r.config, nodeRegistry)
-		if err != nil {
-			logging.Error("core/cluster_scaling: an error occurred while "+
-				"attempting a scaling operation against worker pool %v: %v",
-				workerPool.Name, err)
-			return
+		// Setup a failure message to pass to the failsafe check.
+		msg := &notifier.FailureMessage{
+			AlertUID:     workerPool.NotificationUID,
+			ResourceID:   workerPool.Name,
+			ResourceType: ClusterType,
 		}
 
-		// Obtain a read/write lock on the node registry, write the worker
-		// pool state object back to the node registry and release the lock.
-		nodeRegistry.Lock.Lock()
-		nodeRegistry.WorkerPools[workerPool.Name].State = workerPool.State
-		nodeRegistry.Lock.Unlock()
+		// If the worker pool is in failsafe mode, decline to perform any scaling
+		// evaluation or action.
+		if !FailsafeCheck(workerPool.State, r.config, workerPool.RetryThreshold, msg) {
+			logging.Warning("core/cluster_scaling: worker pool %v is in failsafe "+
+				"mode, no scaling evaluations will be performed", workerPool.Name)
+
+			wg.Done()
+			continue
+		}
+
+		// Evaluate worker pool to determine if a scaling operation is required.
+		scale, err := nomadClient.EvaluatePoolScaling(poolCapacity, workerPool, jobs)
+		if err != nil || !scale {
+			logging.Debug("core/cluster_scaling: scaling operation for worker pool %v "+
+				"is either not required or not permitted: %v", workerPool.Name, err)
+
+			wg.Done()
+			continue
+		}
+
+		// Copy the desired scsaling direction to the state object.
+		workerPool.State.ScalingDirection = poolCapacity.ScalingDirection
+
+		// Attempt to update state tracking information in Consul.
+		if err = consulClient.PersistState(workerPool.State); err != nil {
+			logging.Error("core/cluster_scaling: %v", err)
+		}
+
+		// Call the scaling provider safety check to determine if we should
+		// proceed with scaling evaluation.
+		if scale := workerPool.ScalingProvider.SafetyCheck(workerPool); !scale {
+			logging.Debug("core/cluster_scaling: scaling operation for worker pool %v"+
+				"is not permitted by the scaling provider", workerPool.Name)
+
+			wg.Done()
+			continue
+		}
+
+		// Determine if the scaling cooldown threshold has been met.
+		ok := checkCooldownThreshold(workerPool)
+		if !ok {
+			wg.Done()
+			continue
+		}
+
+		// Determine if we've reached the required number of consecutive scaling
+		// requests.
+		ok = checkPoolScalingThreshold(workerPool, r.config)
+		if !ok {
+			wg.Done()
+			continue
+		}
+
+		if poolCapacity.ScalingDirection != structs.ScalingDirectionNone {
+			scaleMetric := poolCapacity.ScalingMetric
+
+			logging.Info("core/cluster_scaling: worker pool %v requires a scaling "+
+				"operation: (Direction: %v, Nodes: %v, Metric: %v, Capacity: %v, "+
+				"Utilization: %v, Max Allowed: %v)", workerPool.Name,
+				poolCapacity.ScalingDirection, len(workerPool.Nodes), scaleMetric.Type,
+				scaleMetric.Capacity, scaleMetric.Utilization,
+				poolCapacity.MaxAllowedUtilization)
+		}
+
+		if poolCapacity.ScalingDirection == structs.ScalingDirectionOut {
+			// Initiate cluster scaling operation by calling the scaling provider.
+			err = workerPool.ScalingProvider.Scale(workerPool, r.config, nodeRegistry)
+			if err != nil {
+				logging.Error("core/cluster_scaling: an error occurred while "+
+					"attempting a scaling operation against worker pool %v: %v",
+					workerPool.Name, err)
+
+				wg.Done()
+				continue
+			}
+
+			// Obtain a read/write lock on the node registry, write the worker
+			// pool state object back to the node registry and release the lock.
+			nodeRegistry.Lock.Lock()
+			nodeRegistry.WorkerPools[workerPool.Name].State = workerPool.State
+			nodeRegistry.Lock.Unlock()
+		}
+
+		if poolCapacity.ScalingDirection == client.ScalingDirectionIn {
+			// Identify the least allocated node in the worker pool.
+			nodeID, nodeIP := nomadClient.LeastAllocatedNode(poolCapacity,
+				workerPool.ProtectedNode)
+			if nodeIP == "" || nodeID == "" {
+				logging.Error("core/cluster_scaling: unable to identify the least "+
+					"allocated node in worker pool %v", workerPool.Name)
+
+				wg.Done()
+				continue
+			}
+
+			logging.Info("core/cluster_scaling: identified node %v as the least "+
+				"allocated node in worker pool %v", nodeID, workerPool.Name)
+
+			// Register the least allocated node as eligible for scaling actions.
+			workerPool.State.EligibleNodes = append(workerPool.State.EligibleNodes,
+				nodeIP)
+
+			// Place the least allocated noded in drain mode.
+			logging.Info("core/cluster_scaling: placing node %v from worker pool %v "+
+				"in drain mode", nodeID, workerPool.Name)
+
+			if err = nomadClient.DrainNode(nodeID); err != nil {
+				logging.Error("core/cluster_scaling: an error occurred while "+
+					"attempting to place node %v from worker pool %v in drain mode: "+
+					"%v", nodeID, workerPool.Name, err)
+
+				metrics.IncrCounter([]string{"cluster", workerPool.Name, "scale_in",
+					"failure"}, 1)
+
+				wg.Done()
+				continue
+			}
+
+			// Initiate cluster scaling operation by calling the scaling provider.
+			err := workerPool.ScalingProvider.Scale(workerPool, r.config, nodeRegistry)
+			if err != nil {
+				logging.Error("core/cluster_scaling: an error occurred while "+
+					"attempting a scaling operation against worker pool %v: %v",
+					workerPool.Name, err)
+
+				wg.Done()
+				continue
+			}
+
+			// Obtain a read/write lock on the node registry, write the worker
+			// pool state object back to the node registry and release the lock.
+			nodeRegistry.Lock.Lock()
+			nodeRegistry.WorkerPools[workerPool.Name].State = workerPool.State
+			nodeRegistry.Lock.Unlock()
+
+		}
+
+		// Our metric counter to track successful cluster scaling activities.
+		m := fmt.Sprintf("scale_%s", strings.ToLower(poolCapacity.ScalingDirection))
+		metrics.IncrCounter([]string{"cluster", workerPool.Name, m, "success"}, 1)
+
+		// Signal the wait group.
+		wg.Done()
 	}
-
-	if poolCapacity.ScalingDirection == client.ScalingDirectionIn {
-		// Identify the least allocated node in the worker pool.
-		nodeID, nodeIP := nomadClient.LeastAllocatedNode(poolCapacity,
-			workerPool.ProtectedNode)
-		if nodeIP == "" || nodeID == "" {
-			logging.Error("core/cluster_scaling: unable to identify the least "+
-				"allocated node in worker pool %v", workerPool.Name)
-			return
-		}
-
-		logging.Info("core/cluster_scaling: identified node %v as the least "+
-			"allocated node in worker pool %v", nodeID, workerPool.Name)
-
-		// Register the least allocated node as eligible for scaling actions.
-		workerPool.State.EligibleNodes = append(workerPool.State.EligibleNodes,
-			nodeIP)
-
-		// Place the least allocated noded in drain mode.
-		logging.Info("core/cluster_scaling: placing node %v from worker pool %v "+
-			"in drain mode", nodeID, workerPool.Name)
-
-		if err = nomadClient.DrainNode(nodeID); err != nil {
-			logging.Error("core/cluster_scaling: an error occurred while "+
-				"attempting to place node %v from worker pool %v in drain mode: "+
-				"%v", nodeID, workerPool.Name, err)
-
-			metrics.IncrCounter([]string{"cluster", workerPool.Name, "scale_in",
-				"failure"}, 1)
-
-			return
-		}
-
-		// Initiate cluster scaling operation by calling the scaling provider.
-		err := workerPool.ScalingProvider.Scale(workerPool, r.config, nodeRegistry)
-		if err != nil {
-			logging.Error("core/cluster_scaling: an error occurred while "+
-				"attempting a scaling operation against worker pool %v: %v",
-				workerPool.Name, err)
-			return
-		}
-
-		// Obtain a read/write lock on the node registry, write the worker
-		// pool state object back to the node registry and release the lock.
-		nodeRegistry.Lock.Lock()
-		nodeRegistry.WorkerPools[workerPool.Name].State = workerPool.State
-		nodeRegistry.Lock.Unlock()
-
-	}
-
-	// Our metric counter to track successful cluster scaling activities.
-	m := fmt.Sprintf("scale_%s", strings.ToLower(poolCapacity.ScalingDirection))
-	metrics.IncrCounter([]string{"cluster", workerPool.Name, m, "success"}, 1)
-
-	return
 }
 
 // checkPoolScalingThreshold determines if we've reached the required number

--- a/replicator/job_scaling.go
+++ b/replicator/job_scaling.go
@@ -56,6 +56,8 @@ func (r *Runner) asyncJobScaling(jobScalingPolicies *structs.JobScalingPolicies)
 		if r.config.NomadClient.IsJobInDeployment(job) {
 			logging.Debug("core/job_scaling: job %s is in deployment, no scaling "+
 				"evaluation will be triggered", job)
+
+			wg.Done()
 			continue
 		}
 

--- a/replicator/job_scaling.go
+++ b/replicator/job_scaling.go
@@ -27,104 +27,143 @@ func (r *Runner) asyncJobScaling(jobScalingPolicies *structs.JobScalingPolicies)
 	// operations have completed.
 	var wg sync.WaitGroup
 
-	// Register an entry to the wait group for each scalable job.
-	wg.Add(len(jobScalingPolicies.Policies))
+	// Get the current number of registered jobs.
+	jobCount := len(jobScalingPolicies.Policies)
 
+	// Register an entry to the wait group for each scalable job.
+	wg.Add(jobCount)
+
+	// Build a buffered channel to pass our scalable resources to worker threads.
+	jobs := make(chan string, jobCount)
+
+	// Calculate the number of worker threads to initiate.
+	maxConcurrency := r.config.ScalingConcurrency
+
+	if jobCount < maxConcurrency {
+		maxConcurrency = jobCount
+	}
+
+	logging.Debug("code/job_scaling: initiating %v concurrent scaling threads "+
+		"to process %v jobs", maxConcurrency, jobCount)
+
+	// Initiate workers to implement job scaling.
+	for w := 1; w <= maxConcurrency; w++ {
+		go r.jobScaling(w, jobs, jobScalingPolicies, &wg)
+	}
+
+	// Add jobs to the worker channel.
 	for job := range jobScalingPolicies.Policies {
 		if r.config.NomadClient.IsJobInDeployment(job) {
-			logging.Debug("core/job_scaling: job %s is in deployment, no scaling evaluation will be triggerd", job)
+			logging.Debug("core/job_scaling: job %s is in deployment, no scaling "+
+				"evaluation will be triggered", job)
 			continue
 		}
-		go r.jobScaling(job, jobScalingPolicies, &wg)
+
+		jobs <- job
 	}
 
 	// Block on all job scaling threads.
 	wg.Wait()
 }
 
-func (r *Runner) jobScaling(jobName string,
+func (r *Runner) jobScaling(id int, jobs <-chan string,
 	jobScalingPolicies *structs.JobScalingPolicies, wg *sync.WaitGroup) {
 
-	// Inform the wait group we have finished our task upon completion.
-	defer wg.Done()
-
-	g := jobScalingPolicies.Policies[jobName]
-
-	// Scaling a Cluster Jobs requires access to both Consul and Nomad therefore
-	// we setup the clients here.
+	// Setup references to clients for Nomad and Consul.
 	nomadClient := r.config.NomadClient
 	consulClient := r.config.ConsulClient
 
-	// EvaluateJobScaling performs read/write to our map therefore we wrap it
-	// in a read/write lock and remove this as soon as possible as the
-	// remaining functions only need a read lock.
-	jobScalingPolicies.Lock.Lock()
-	err := nomadClient.EvaluateJobScaling(jobName, g)
-	jobScalingPolicies.Lock.Unlock()
+	for jobName := range jobs {
+		logging.Debug("core/job_scaling: scaling thread %v evaluating scaling "+
+			"for job %v", id, jobName)
 
-	// Horrible but required for jobs that have been purged as the policy
-	// watcher will not get notified and such cannot remove the policy even
-	// though the job doesn't exist. The string check is due to
-	// github.com/hashicorp/nomad/issues/1849
-	if err != nil && strings.Contains(err.Error(), "404") {
-		client.RemoveJobScalingPolicy(jobName, jobScalingPolicies)
-		return
-	} else if err != nil {
-		logging.Error("core/job_scaling: unable to perform job resource evaluation: %v", err)
-		return
-	}
+		g := jobScalingPolicies.Policies[jobName]
 
-	jobScalingPolicies.Lock.RLock()
-	for _, group := range g {
-		// Setup a failure message to pass to the failsafe check.
-		message := &notifier.FailureMessage{
-			AlertUID:     group.UID,
-			ResourceID:   fmt.Sprintf("%s/%s", jobName, group.GroupName),
-			ResourceType: JobType,
-		}
+		// EvaluateJobScaling performs read/write to our map therefore we wrap it
+		// in a read/write lock and remove this as soon as possible as the
+		// remaining functions only need a read lock.
+		jobScalingPolicies.Lock.Lock()
+		err := nomadClient.EvaluateJobScaling(jobName, g)
+		jobScalingPolicies.Lock.Unlock()
 
-		// Read or JobGroup state and check failsafe.
-		s := &structs.ScalingState{
-			ResourceName: group.GroupName,
-			ResourceType: JobType,
-			StatePath: r.config.ConsulKeyRoot + "/state/jobs/" + jobName +
-				"/" + group.GroupName,
-		}
-		consulClient.ReadState(s, true)
+		// Horrible but required for jobs that have been purged as the policy
+		// watcher will not get notified and as such, cannot remove the policy even
+		// though the job doesn't exist. The string check is due to
+		// github.com/hashicorp/nomad/issues/1849
+		if err != nil && strings.Contains(err.Error(), "404") {
+			client.RemoveJobScalingPolicy(jobName, jobScalingPolicies)
 
-		if !FailsafeCheck(s, r.config, 1, message) {
-			logging.Error("core/job_scaling: job \"%v\" and group \"%v\" is in "+
-				"failsafe mode", jobName, group.GroupName)
+			// Signal the wait group.
+			wg.Done()
+
+			continue
+		} else if err != nil {
+			logging.Error("core/job_scaling: unable to perform job resource "+
+				"evaluation: %v", err)
+
+			// Signal the wait group.
+			wg.Done()
+
 			continue
 		}
 
-		// Check the JobGroup scaling cooldown.
-		cd := time.Duration(group.Cooldown) * time.Second
+		jobScalingPolicies.Lock.RLock()
 
-		if !s.LastScalingEvent.Before(time.Now().Add(-cd)) {
-			logging.Debug("core/job_scaling: job \"%v\" and group \"%v\" has not reached scaling cooldown threshold of %s",
-				jobName, group.GroupName, cd)
-			continue
-		}
-
-		if group.ScaleDirection == client.ScalingDirectionOut || group.ScaleDirection == client.ScalingDirectionIn {
-			if group.Enabled {
-				logging.Debug("core/job_scaling: scaling for job \"%v\" and group \"%v\" is enabled; a "+
-					"scaling operation (%v) will be requested", jobName, group.GroupName, group.ScaleDirection)
-
-				// Submit the job and group for scaling.
-				nomadClient.JobGroupScale(jobName, group, s)
-
-			} else {
-				logging.Debug("core/job_scaling: job scaling has been disabled; a "+
-					"scaling operation (%v) would have been requested for \"%v\" "+
-					"and group \"%v\"", group.ScaleDirection, jobName, group.GroupName)
+		for _, group := range g {
+			// Setup a failure message to pass to the failsafe check.
+			message := &notifier.FailureMessage{
+				AlertUID:     group.UID,
+				ResourceID:   fmt.Sprintf("%s/%s", jobName, group.GroupName),
+				ResourceType: JobType,
 			}
+
+			// Read our JobGroup state and check failsafe.
+			s := &structs.ScalingState{
+				ResourceName: group.GroupName,
+				ResourceType: JobType,
+				StatePath: r.config.ConsulKeyRoot + "/state/jobs/" + jobName +
+					"/" + group.GroupName,
+			}
+			consulClient.ReadState(s, true)
+
+			if !FailsafeCheck(s, r.config, 1, message) {
+				logging.Error("core/job_scaling: job \"%v\" and group \"%v\" is in "+
+					"failsafe mode", jobName, group.GroupName)
+				continue
+			}
+
+			// Check the JobGroup scaling cooldown.
+			cd := time.Duration(group.Cooldown) * time.Second
+
+			if !s.LastScalingEvent.Before(time.Now().Add(-cd)) {
+				logging.Debug("core/job_scaling: job \"%v\" and group \"%v\" has not reached scaling cooldown threshold of %s",
+					jobName, group.GroupName, cd)
+				continue
+			}
+
+			if group.ScaleDirection == client.ScalingDirectionOut || group.ScaleDirection == client.ScalingDirectionIn {
+				if group.Enabled {
+					logging.Debug("core/job_scaling: scaling for job \"%v\" and group \"%v\" is enabled; a "+
+						"scaling operation (%v) will be requested", jobName, group.GroupName, group.ScaleDirection)
+
+					// Submit the job and group for scaling.
+					nomadClient.JobGroupScale(jobName, group, s)
+
+				} else {
+					logging.Debug("core/job_scaling: job scaling has been disabled; a "+
+						"scaling operation (%v) would have been requested for \"%v\" "+
+						"and group \"%v\"", group.ScaleDirection, jobName, group.GroupName)
+				}
+			}
+
+			// Persist our state to Consul.
+			consulClient.PersistState(s)
 		}
 
-		// Persist our state to Consul.
-		consulClient.PersistState(s)
+		// Release our read-only lock.
+		jobScalingPolicies.Lock.RUnlock()
 
+		// Signal the wait group.
+		wg.Done()
 	}
-	jobScalingPolicies.Lock.RUnlock()
 }

--- a/replicator/runner.go
+++ b/replicator/runner.go
@@ -95,7 +95,7 @@ func (r *Runner) jobScalingTicker(jobPol *structs.JobScalingPolicies) {
 	for {
 		select {
 		case <-ticker.C:
-			if r.candidate.isLeader() {
+			if r.candidate.isLeader() && len(jobPol.Policies) > 0 {
 				r.asyncJobScaling(jobPol)
 			}
 		case <-r.doneChan:
@@ -113,7 +113,7 @@ func (r *Runner) clusterScalingTicker(nodeReg *structs.NodeRegistry, jobPol *str
 	for {
 		select {
 		case <-ticker.C:
-			if r.candidate.isLeader() {
+			if r.candidate.isLeader() && len(nodeReg.WorkerPools) > 0 {
 				err := r.nodeProtectionCheck(nodeReg)
 				if err != nil {
 					logging.Error("core/runner: an error occurred while trying to "+

--- a/replicator/structs/config.go
+++ b/replicator/structs/config.go
@@ -52,6 +52,10 @@ type Config struct {
 	// initialized backends.
 	Notification *Notification `mapstructure:"notification"`
 
+	// ScalingConcurrency sets the maximum number of concurrent scaling
+	// operations allowed for both job and worker pool scaling.
+	ScalingConcurrency int `mapstructure:"scaling_concurrency"`
+
 	// Telemetry is the configuration struct that controls the telemetry settings.
 	Telemetry *Telemetry `mapstructure:"telemetry"`
 }
@@ -117,6 +121,10 @@ func (c *Config) Merge(b *Config) *Config {
 
 	if b.JobScalingDisable {
 		config.JobScalingDisable = b.JobScalingDisable
+	}
+
+	if b.ScalingConcurrency > 0 {
+		config.ScalingConcurrency = b.ScalingConcurrency
 	}
 
 	// Apply the Telemetry config


### PR DESCRIPTION
This commit changes the concurrency model for both job and worker
pool scaling operations. Previously, Replicator would initiate a
concurrent thread for each scalable resource with no upper-bound
limit to the number of concurrent scaling operations.

Under this patch, Replicator introduces a new configuration flag,
`-scaling-concurrency` which defaults to `10`. Under the new
concurrency model, Replicator will create up to the maximum
declared number of scaling workers. Scalable resources are passed
to the worker threads via a buffered channel and the async methods
perform work accounting via a `sync.WaitGroup`.

If the number of scalable resources is less than the declared max
concurrency, only the required number worker threads are instantiated.

Closes #223 and #221