### PR TITLE
Add /status/leader API endpoint functionality.

### DIFF
--- a/api/status.go
+++ b/api/status.go
@@ -1,0 +1,25 @@
+package api
+
+import "github.com/elsevier-core-engineering/replicator/replicator/structs"
+
+// Status is used to query all status related endpoints.
+type Status struct {
+	client *Client
+}
+
+// Status returns a handle on the status related endpoints.
+func (c *Client) Status() *Status {
+	return &Status{client: c}
+}
+
+// Leader is used to query information regarding the current Replicator leader.
+func (s *Status) Leader() (structs.LeaderResponse, error) {
+	var resp structs.LeaderResponse
+
+	err := s.client.query("/v1/status/leader", &resp)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -120,6 +120,7 @@ func (s *HTTPServer) Shutdown() {
 
 // registerHandlers is used to attach our handlers.
 func (s *HTTPServer) registerHandlers() {
+	s.mux.HandleFunc("/v1/status/leader", s.wrap(s.StatusLeaderRequest))
 }
 
 func (s *HTTPServer) wrap(handler func(resp http.ResponseWriter, req *http.Request) (interface{}, error)) func(resp http.ResponseWriter, req *http.Request) {

--- a/command/agent/status_endpoint.go
+++ b/command/agent/status_endpoint.go
@@ -1,0 +1,20 @@
+package agent
+
+import (
+	"net/http"
+
+	"github.com/elsevier-core-engineering/replicator/replicator/structs"
+)
+
+// StatusLeaderRequest is used to perform the Status.Leader API request.
+func (s *HTTPServer) StatusLeaderRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	if req.Method != "GET" {
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+
+	var leader structs.LeaderResponse
+	if err := s.agent.RPC("Status.Leader", &leader); err != nil {
+		return nil, err
+	}
+	return leader, nil
+}

--- a/replicator/server.go
+++ b/replicator/server.go
@@ -35,6 +35,7 @@ type Server struct {
 
 // endpoints represents the Replicator API endpoints.
 type endpoints struct {
+	Status *Status
 }
 
 type inmemCodec struct {
@@ -170,6 +171,9 @@ func (s *Server) clusterScalingTicker(nodeReg *structs.NodeRegistry, jobPol *str
 // setupRPC is used to setup our endpoints and register the handlers as well as
 // setup the RPC listener.
 func (s *Server) setupRPC() error {
+
+	s.endpoints.Status = &Status{s}
+	s.rpcServer.Register(s.endpoints.Status)
 
 	list, err := net.ListenTCP("tcp", s.config.RPCAddr)
 	if err != nil {

--- a/replicator/status_endpoint.go
+++ b/replicator/status_endpoint.go
@@ -1,0 +1,30 @@
+package replicator
+
+import (
+	"github.com/elsevier-core-engineering/replicator/replicator/structs"
+)
+
+// Status endpoint is used to get information on the server status.
+type Status struct {
+	srv *Server
+}
+
+// Leader gets information regarding the Replicator instance which is holding
+// leadership.
+func (s *Status) Leader(args interface{}, reply *structs.LeaderResponse) error {
+
+	var session string
+
+	if s.srv.candidate.leader {
+		session = s.srv.candidate.session
+	} else {
+		session = ""
+	}
+
+	err := s.srv.config.ConsulClient.GetLeaderInfo(reply, &s.srv.candidate.key, session)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/replicator/structs/consul.go
+++ b/replicator/structs/consul.go
@@ -13,6 +13,10 @@ type ConsulClient interface {
 	// leadership can be maintained.
 	CreateSession(int, chan struct{}) (string, error)
 
+	// GetLeaderInfo is used to inspect the leadership KV and session to provide
+	// details of the Replicator agent currently holding leadership.
+	GetLeaderInfo(*LeaderResponse, *string, string) error
+
 	// PersistState is responsible for persistently storing scaling
 	// state information in the Consul Key/Value Store.
 	PersistState(*ScalingState) error

--- a/replicator/structs/structs.go
+++ b/replicator/structs/structs.go
@@ -1,0 +1,7 @@
+package structs
+
+// LeaderResponse is used for the Status.Leader response.
+type LeaderResponse struct {
+	SessionID string
+	NodeID    string
+}


### PR DESCRIPTION
This commit introduces the first Replicator API endpoint which can
be called at `/v1/status/leader` and returns a JSON block that
details the leader Replicator instance which currently holds the
Consul lock.

Example response:
```
{
  "NodeID":"REDACTED",
  "SessionID":"5f9b250f-70bd-a59a-fd44-9c4e54f5ac27"
}
```

Once this has been accepted I will raise a ticket to document the API and this endpoint.

Closes #239 