### PR TITLE
Fix issue where Replicator wouldn't log when RPC bind is in use.

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -63,6 +63,7 @@ func (c *Command) Run(args []string) int {
 	// Create the initial runner with the merged configuration parameters.
 	server, err := replicator.NewServer(conf)
 	if err != nil {
+		logging.Error("command/agent: failed to start Replicator server: %s", err)
 		return 1
 	}
 


### PR DESCRIPTION
This adds a logging line in the agent command to log if Replicator
tries to start and the RPC bind address is in use. Previously
this would just silently fail.

Closes #241