### PR TITLE
Implement Worker Pool Configuration Fallback From Consul

### DIFF
--- a/client/consul.go
+++ b/client/consul.go
@@ -1,14 +1,16 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"runtime"
 	"time"
 
 	metrics "github.com/armon/go-metrics"
+	consul "github.com/hashicorp/consul/api"
+
 	"github.com/elsevier-core-engineering/replicator/logging"
 	"github.com/elsevier-core-engineering/replicator/replicator/structs"
-	consul "github.com/hashicorp/consul/api"
 )
 
 // The client object is a wrapper to the Consul client provided by the Consul
@@ -60,6 +62,26 @@ func (c *consulClient) CreateSession(ttl int, stopCh chan struct{}) (id string, 
 	c.renewSession(entry.TTL, resp, stopCh)
 
 	return resp, nil
+}
+
+// LoadPoolConfig retrieves fallback worker pool configuration from Consul.
+func (c *consulClient) LoadPoolConfig(key string) (map[string]string, error) {
+	// Attempt to read the pool configuration key, if present.
+	config, _, err := c.consul.KV().Get(key, nil)
+	if err != nil || config == nil {
+		return nil, fmt.Errorf("unable to find or read pool configuration data "+
+			"at path %v: %v", key, err)
+	}
+
+	// Marshal result into map object.
+	result := make(map[string]string)
+	err = json.Unmarshal(config.Value, &result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process pool configuration data read "+
+			"from path %v: %v", key, err)
+	}
+
+	return result, nil
 }
 
 // AcquireLeadership attempts to acquire a Consul leadersip lock using the

--- a/client/node_discovery_test.go
+++ b/client/node_discovery_test.go
@@ -147,7 +147,7 @@ func TestNodeDiscovery_ProcessNodeConfig(t *testing.T) {
 		// Test that a node with only a worker pool name in the meta config and
 		// a partial fallback configuration fails.
 		data := []byte(`{"replicator_enabled":"true",
-                                 "replicator_worker_pool":"example-group"}`)
+                                "replicator_worker_pool":"example-group"}`)
 		server.SetKV("replicator/config/nodes/example-group", data)
 
 		_, err = ProcessNodeConfig(nodeRecord, config)
@@ -159,10 +159,10 @@ func TestNodeDiscovery_ProcessNodeConfig(t *testing.T) {
 		// Test that a node with only a worker pool name in the meta config can
 		// successfully find fallback configuration.
 		data = []byte(`{"replicator_enabled":"true",
-                                "replicator_notification_uid":"REP2",
-                                "replicator_provider":"aws",
-                                "replicator_region":"us-east-1",
-                                "replicator_worker_pool":"example-group"}`)
+                               "replicator_notification_uid":"REP2",
+                               "replicator_provider":"aws",
+                               "replicator_region":"us-east-1",
+                               "replicator_worker_pool":"example-group"}`)
 		server.SetKV("replicator/config/nodes/example-group", data)
 
 		_, err = ProcessNodeConfig(nodeRecord, config)

--- a/client/node_discovery_test.go
+++ b/client/node_discovery_test.go
@@ -147,7 +147,7 @@ func TestNodeDiscovery_ProcessNodeConfig(t *testing.T) {
 		// Test that a node with only a worker pool name in the meta config and
 		// a partial fallback configuration fails.
 		data := []byte(`{"replicator_enabled":"true",
-										 "replicator_worker_pool":"example-group"}`)
+                                 "replicator_worker_pool":"example-group"}`)
 		server.SetKV("replicator/config/nodes/example-group", data)
 
 		_, err = ProcessNodeConfig(nodeRecord, config)
@@ -159,10 +159,10 @@ func TestNodeDiscovery_ProcessNodeConfig(t *testing.T) {
 		// Test that a node with only a worker pool name in the meta config can
 		// successfully find fallback configuration.
 		data = []byte(`{"replicator_enabled":"true",
-										 "replicator_notification_uid":"REP2",
-										 "replicator_provider":"aws",
-										 "replicator_region":"us-east-1",
-										 "replicator_worker_pool":"example-group"}`)
+                                "replicator_notification_uid":"REP2",
+                                "replicator_provider":"aws",
+                                "replicator_region":"us-east-1",
+                                "replicator_worker_pool":"example-group"}`)
 		server.SetKV("replicator/config/nodes/example-group", data)
 
 		_, err = ProcessNodeConfig(nodeRecord, config)

--- a/cloud/aws/aws_cloud_provider.go
+++ b/cloud/aws/aws_cloud_provider.go
@@ -24,15 +24,14 @@ type AwsScalingProvider struct {
 
 // NewAwsScalingProvider is a factory function that generates a new instance
 // of the AwsScalingProvider.
-func NewAwsScalingProvider(conf map[string]string) (structs.ScalingProvider, error) {
-	region, ok := conf["replicator_region"]
-	if !ok {
+func NewAwsScalingProvider(workerPool *structs.WorkerPool) (structs.ScalingProvider, error) {
+	if workerPool.Region == "" {
 		return nil, fmt.Errorf("replicator_region is required for the aws " +
 			"scaling provider")
 	}
 
 	return &AwsScalingProvider{
-		AsgService: newAwsAsgService(region),
+		AsgService: newAwsAsgService(workerPool.Region),
 	}, nil
 }
 

--- a/cloud/cloud_provider.go
+++ b/cloud/cloud_provider.go
@@ -19,20 +19,19 @@ var BuiltinScalingProviders = map[string]ScalingProviderFactory{
 // ScalingProviderFactory is a factory method type for instantiating a new
 // instance of a scaling provider.
 type ScalingProviderFactory func(
-	conf map[string]string) (structs.ScalingProvider, error)
+	conf *structs.WorkerPool) (structs.ScalingProvider, error)
 
 // NewScalingProvider is the entry point method for processing the scaling
 // provider configuration in worker pool nodes, finding the correct factory
 // method and setting up the scaling provider.
-func NewScalingProvider(conf map[string]string) (structs.ScalingProvider, error) {
+func NewScalingProvider(workerPool *structs.WorkerPool) (structs.ScalingProvider, error) {
 	// Query configuration for scaling provider name.
-	providerName, ok := conf["replicator_provider"]
-	if !ok {
+	if workerPool.ProviderName == "" {
 		return nil, fmt.Errorf("no scaling provider specified")
 	}
 
 	// Lookup the scaling provider factory function.
-	providerFactory, ok := BuiltinScalingProviders[providerName]
+	providerFactory, ok := BuiltinScalingProviders[workerPool.ProviderName]
 	if !ok {
 		// Build a list of all supported scaling providers.
 		providers := reflect.ValueOf(BuiltinScalingProviders).MapKeys()
@@ -43,18 +42,18 @@ func NewScalingProvider(conf map[string]string) (structs.ScalingProvider, error)
 		}
 
 		return nil, fmt.Errorf("unknown scaling provider %v, must be one of: %v",
-			providerName, strings.Join(availableProviders, ","))
+			workerPool.ProviderName, strings.Join(availableProviders, ","))
 	}
 
 	// Setup the scaling provider.
-	scalingProvider, err := providerFactory(conf)
+	scalingProvider, err := providerFactory(workerPool)
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred while setting up scaling "+
-			"provider %v: %v", providerName, err)
+			"provider %v: %v", workerPool.ProviderName, err)
 	}
 
 	logging.Debug("cloud/scaling_provider: initialized scaling provider %v "+
-		"for worker pool %v", providerName, conf["replicator_worker_pool"])
+		"for worker pool %v", workerPool.ProviderName, workerPool.Name)
 
 	return scalingProvider, nil
 }

--- a/cloud/cloud_provider_test.go
+++ b/cloud/cloud_provider_test.go
@@ -2,6 +2,8 @@ package cloud
 
 import (
 	"testing"
+
+	"github.com/elsevier-core-engineering/replicator/replicator/structs"
 )
 
 // Test the parsing of scaling meta configuration parameters and
@@ -9,36 +11,32 @@ import (
 func TestScalingProvider_ProviderFactory(t *testing.T) {
 	// Verify an error is thrown when we pass a configuration without
 	// specifying the replicator_provider entry.
-	conf := map[string]string{
-		"replicator_foo": "aws",
-	}
+	workerPool := structs.NewWorkerPool()
 
-	if _, err := NewScalingProvider(conf); err == nil {
+	if _, err := NewScalingProvider(workerPool); err == nil {
 		t.Fatalf("no exception was raised when we attempted to create a scaling " +
 			"provider without specifying the required parameters")
 	}
 
 	// Verify an exception is thrown when we specify an invalid scaling
 	// provider.
-	conf = map[string]string{
-		"replicator_provider": "foo",
-	}
-	if _, err := NewScalingProvider(conf); err == nil {
+	workerPool.ProviderName = "foo"
+	if _, err := NewScalingProvider(workerPool); err == nil {
 		t.Fatalf("no exception was raised when we attempted to create a scaling " +
 			"provider with an invalid provider type")
 	}
 
 	// Verify an exception is thrown when we specify a valid scaling provider
 	// but don't include the other required configuration parameters.
-	conf["replicator_provider"] = "aws"
-	if _, err := NewScalingProvider(conf); err == nil {
+	workerPool.ProviderName = "aws"
+	if _, err := NewScalingProvider(workerPool); err == nil {
 		t.Fatalf("no exception was raised when we specified a valid scaling " +
 			"provider but failed to include all required configuration parameters")
 	}
 
 	// Verify no exception is raised when we pass all required parameters.
-	conf["replicator_region"] = "us-east-1"
-	if _, err := NewScalingProvider(conf); err != nil {
+	workerPool.Region = "us-east-1"
+	if _, err := NewScalingProvider(workerPool); err != nil {
 		t.Fatalf("an exception was raised when we specified a valid scaling " +
 			"provider and all required configuration parameters")
 	}

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -44,6 +44,16 @@ func Min(values ...float64) float64 {
 	return min
 }
 
+// StringInSlice checks if a given string is in a slice.
+func StringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
 // ParseMetaConfig parses meta parameters from a Nomad agent or job
 // configuration and validates required keys are present. If any required
 // keys are found to be missing, these are returned. Otherwise, an empty

--- a/helper/funcs_test.go
+++ b/helper/funcs_test.go
@@ -27,6 +27,27 @@ func TestHelper_Max(t *testing.T) {
 	}
 }
 
+func TestHelper_StringInList(t *testing.T) {
+	type stringTest struct {
+		input    string
+		expected bool
+	}
+
+	var stringTests = []stringTest{
+		{"goo", false}, {"foo", true},
+	}
+
+	list := []string{"foo", "bar"}
+
+	for _, test := range stringTests {
+		actual := StringInSlice(test.input, list)
+
+		if actual != test.expected {
+			t.Fatalf("expected %v got %v", test.expected, actual)
+		}
+	}
+}
+
 func TestHelper_Min(t *testing.T) {
 
 	expected := 1.01

--- a/replicator/server.go
+++ b/replicator/server.go
@@ -70,7 +70,7 @@ func NewServer(config *structs.Config) (*Server, error) {
 	if !s.config.ClusterScalingDisable {
 		// Setup the node registry and initiate worker pool and node discovery.
 		nodeRegistry := structs.NewNodeRegistry()
-		go s.config.NomadClient.NodeWatcher(nodeRegistry)
+		go s.config.NomadClient.NodeWatcher(nodeRegistry, s.config)
 
 		// Launch our cluster scaling main ticker function
 		go s.clusterScalingTicker(nodeRegistry, jobScalingPolicy)

--- a/replicator/structs/consul.go
+++ b/replicator/structs/consul.go
@@ -12,15 +12,15 @@ type ConsulClient interface {
 	// process and will spawn off the renewing of the session in order to ensure
 	// leadership can be maintained.
 	CreateSession(int, chan struct{}) (string, error)
-  
+
 	// GetLeaderInfo is used to inspect the leadership KV and session to provide
 	// details of the Replicator agent currently holding leadership.
 	GetLeaderInfo(*LeaderResponse, *string, string) error
 
-  // LoadPoolConfig is responsible for performing fallback loading of a
+	// LoadPoolConfig is responsible for performing fallback loading of a
 	// worker pool configuration from Consul.
 	LoadPoolConfig(string) (map[string]string, error)
-  
+
 	// PersistState is responsible for persistently storing scaling
 	// state information in the Consul Key/Value Store.
 	PersistState(*ScalingState) error

--- a/replicator/structs/consul.go
+++ b/replicator/structs/consul.go
@@ -13,6 +13,10 @@ type ConsulClient interface {
 	// leadership can be maintained.
 	CreateSession(int, chan struct{}) (string, error)
 
+	// LoadPoolConfig is responsible for performing fallback loading of a
+	// worker pool configuration from Consul.
+	LoadPoolConfig(string) (map[string]string, error)
+
 	// PersistState is responsible for persistently storing scaling
 	// state information in the Consul Key/Value Store.
 	PersistState(*ScalingState) error

--- a/replicator/structs/node_discovery.go
+++ b/replicator/structs/node_discovery.go
@@ -51,6 +51,7 @@ type WorkerPool struct {
 	Nodes             map[string]*nomad.Node `hash:"ignore"`
 	NotificationUID   string                 `mapstructure:"replicator_notification_uid"`
 	ProtectedNode     string                 `hash:"ignore"`
+	ProviderName      string                 `hash:"ignore" mapstructure:"replicator_provider"`
 	Region            string                 `mapstructure:"replicator_region"`
 	RetryThreshold    int                    `mapstructure:"replicator_retry_threshold"`
 	ScalingEnabled    bool                   `mapstructure:"replicator_enabled"`

--- a/replicator/structs/nomad.go
+++ b/replicator/structs/nomad.go
@@ -66,7 +66,7 @@ type NomadClient interface {
 
 	// NodeWatcher provides an automated mechanism to discover worker pools and
 	// nodes and populate the node registry.
-	NodeWatcher(*NodeRegistry)
+	NodeWatcher(*NodeRegistry, *Config)
 
 	// MostUtilizedResource calculates which resource is most-utilized across the
 	// cluster. The worst-case allocation resource is prioritized when making


### PR DESCRIPTION
This commit introduces support for minimizing the required Replicator
configuration that must be added to the client meta section.

A fallback configuration lookup feature has been added for the node
discovery mechanism. With this feature, when node discovery
encounters a node where only the `replicator_worker_pool` meta
parameter is set, Replicator will attempt to find the rest of the
worker pool configuration parameters in the Consul key/value store.

Replicator searches down the Consul root key path defined in
`consul_key_root`.

To use this feature, you would set the worker pool name in each
node configuration:

```
meta {
   "replicator_worker_pool" = "example-worker-pool"
}
```

Then place the full worker pool configuration in a Consul key
located at `replicator/config/nodes/example-worker-pool`:

```
{
  "replicator_enabled": "true",
  "replicator_notification_uid": "REP2",
  "replicator_provider": "aws",
  "replicator_region": "us-east-1",
  "replicator_worker_pool": "example-worker-pool"
}
```

This commit introduces only the fallback config lookup mechanism; a
future commit will introduce a watch against Consul and automatic
reloading when the Consul configuration is changed.

Closes #204