### PR TITLE
Fix Cluster Scaling When Disk Metric Prioritized

### DIFF
--- a/client/nomad.go
+++ b/client/nomad.go
@@ -131,13 +131,18 @@ func (c *nomadClient) LeastAllocatedNode(capacity *structs.ClusterCapacity,
 		switch capacity.ScalingMetric.Type {
 		case ScalingMetricProcessor:
 			if (lowest == 0) || (alloc.UsedCapacity.CPUPercent < lowest) {
-				nodeID = alloc.NodeID
 				lowest = alloc.UsedCapacity.CPUPercent
+				nodeID = alloc.NodeID
 			}
 		case ScalingMetricMemory:
 			if (lowest == 0) || (alloc.UsedCapacity.MemoryPercent < lowest) {
-				nodeID = alloc.NodeID
 				lowest = alloc.UsedCapacity.MemoryPercent
+				nodeID = alloc.NodeID
+			}
+		case ScalingMetricDisk:
+			if (lowest == 0) || (alloc.UsedCapacity.DiskPercent < lowest) {
+				lowest = alloc.UsedCapacity.DiskPercent
+				nodeID = alloc.NodeID
 			}
 		case ScalingMetricNone:
 			nodeID = alloc.NodeID


### PR DESCRIPTION
This commit fixes a bug in the `LeastAllocatedNode` method that
results in an error when Replicator attempts to initiate a cluster
scale-in operation if the prioritized scaling metric is set to
`ScalingMetricDisk`.

Closes #240