### PR TITLE
fix: do not run make release unless the travis build is for a git tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 script:
 - make test
 after_success:
-- make release
+- if [[ -n "$TRAVIS_TAG" ]]; then make release; fi
 notifications:
   email: true
 deploy:


### PR DESCRIPTION
The list of available travis environment variables is [here](https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables).

Closes elsevier-core-engineering/replicator#235