### PR TITLE
Increase timeout for ASG scaling result

### DIFF
--- a/cloud/aws/aws_asg_util.go
+++ b/cloud/aws/aws_asg_util.go
@@ -178,7 +178,7 @@ func checkClusterScalingResult(activityID *string,
 
 	// Setup our timeout and ticker value.
 	ticker := time.NewTicker(time.Second * time.Duration(10))
-	timeOut := time.Tick(time.Minute * 3)
+	timeOut := time.Tick(time.Minute * 10)
 
 	for {
 		select {


### PR DESCRIPTION
In the event that the ASG is associated with an ELB the default period
for connection draining is 300 seconds / 5 minutes. This pushes the
timeout further out to 10 minutes.

Perhaps the ASG should be queried for the connection draining period and
have that added to the timeout instead?