### PR TITLE
Fix timeout to use Ticker vs Tick

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,31 +137,32 @@ Until Vault integration is added, the instance pool which is capable of running 
 
 ```json
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AuthorizeAutoScalingActions",
-      "Action": [
-        "autoscaling:DescribeAutoScalingGroups",
-        "autoscaling:DescribeAutoScalingInstances",
-        "autoscaling:DescribeScalingActivities",
-        "autoscaling:DetachInstances",
-        "autoscaling:UpdateAutoScalingGroup"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    },
-    {
-      "Sid": "AuthorizeEC2Actions",
-      "Action": [
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions",
-        "ec2:TerminateInstances"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AuthorizeAutoScalingActions",
+            "Action": [
+                "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeScalingActivities",
+                "autoscaling:DetachInstances",
+                "autoscaling:UpdateAutoScalingGroup"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Sid": "AuthorizeEC2Actions",
+            "Action": [
+                "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
+                "ec2:TerminateInstances",
+                "ec2:DescribeInstanceStatus"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ]
 }
 ```
 

--- a/client/nomad.go
+++ b/client/nomad.go
@@ -181,11 +181,14 @@ func (c *nomadClient) DrainNode(nodeID string) (err error) {
 	// Setup a ticker to poll the node allocations and report when all existing
 	// allocations have been migrated to other worker nodes.
 	ticker := time.NewTicker(time.Millisecond * 500)
-	timeout := time.Tick(time.Minute * 3)
+	defer ticker.Stop()
+
+	timeout := time.NewTicker(time.Minute * 3)
+	defer timeout.Stop()
 
 	for {
 		select {
-		case <-timeout:
+		case <-timeout.C:
 			logging.Error("client/nomad: timeout %v reached while waiting for existing allocations to be migrated from node %v",
 				timeout, nodeID)
 			return nil
@@ -312,14 +315,17 @@ func (c *nomadClient) VerifyNodeHealth(nodeIP string) (healthy bool) {
 	// Setup a ticker to poll the health status of the specified worker node
 	// and retry up to a specified timeout.
 	ticker := time.NewTicker(time.Second * 10)
-	timeout := time.Tick(time.Minute * 5)
+	defer ticker.Stop()
+
+	timeout := time.NewTicker(time.Minute * 5)
+	defer timeout.Stop()
 
 	logging.Info("client/nomad: waiting for node %v to successfully join "+
 		"the worker pool", nodeIP)
 
 	for {
 		select {
-		case <-timeout:
+		case <-timeout.C:
 			logging.Error("client/nomad: timeout reached while verifying the "+
 				"health of worker node %v", nodeIP)
 			return

--- a/cloud/aws/aws_asg_util.go
+++ b/cloud/aws/aws_asg_util.go
@@ -48,6 +48,7 @@ func getMostRecentInstance(asg, region string) (node string, err error) {
 	// launched instance and retry up to a specified timeout.
 	ticker := time.NewTicker(time.Second * 10)
 	timeout := time.NewTicker(time.Minute * 5)
+	defer timeout.Stop()
 
 	// Setup AWS EC2 API Session
 	sess := session.Must(session.NewSession())
@@ -78,7 +79,7 @@ func getMostRecentInstance(asg, region string) (node string, err error) {
 
 	for {
 		select {
-		case <-timeout:
+		case <-timeout.C:
 			err = fmt.Errorf("cloud/aws: timeout reached while attempting to "+
 				"determine the most recently launched instance in autoscaling "+
 				"group %v", asg)

--- a/cloud/aws/aws_asg_util.go
+++ b/cloud/aws/aws_asg_util.go
@@ -47,7 +47,7 @@ func getMostRecentInstance(asg, region string) (node string, err error) {
 	// Setup a ticker to poll the autoscaling group for a recently
 	// launched instance and retry up to a specified timeout.
 	ticker := time.NewTicker(time.Second * 10)
-	timeout := time.Tick(time.Minute * 5)
+	timeout := time.NewTicker(time.Minute * 5)
 
 	// Setup AWS EC2 API Session
 	sess := session.Must(session.NewSession())

--- a/cloud/aws/aws_asg_util.go
+++ b/cloud/aws/aws_asg_util.go
@@ -47,6 +47,8 @@ func getMostRecentInstance(asg, region string) (node string, err error) {
 	// Setup a ticker to poll the autoscaling group for a recently
 	// launched instance and retry up to a specified timeout.
 	ticker := time.NewTicker(time.Second * 10)
+	defer ticker.Stop()
+
 	timeout := time.NewTicker(time.Minute * 5)
 	defer timeout.Stop()
 
@@ -179,11 +181,14 @@ func checkClusterScalingResult(activityID *string,
 
 	// Setup our timeout and ticker value.
 	ticker := time.NewTicker(time.Second * time.Duration(10))
-	timeOut := time.Tick(time.Minute * 10)
+	defer ticker.Stop()
+
+	timeOut := time.NewTicker(time.Minute * 10)
+	defer timeOut.Stop()
 
 	for {
 		select {
-		case <-timeOut:
+		case <-timeOut.C:
 			return fmt.Errorf("timeout reached while attempting to verify scaling "+
 				"activity %v completed successfully", activityID)
 
@@ -222,7 +227,10 @@ func verifyAsgUpdate(workerPool string, capacity int64,
 	// Setup a ticker to poll the autoscaling group and report when an instance
 	// has been successfully launched.
 	ticker := time.NewTicker(time.Millisecond * 500)
-	timeout := time.Tick(time.Minute * 3)
+	defer ticker.Stop()
+
+	timeout := time.NewTicker(time.Minute * 3)
+	defer timeout.Stop()
 
 	logging.Info("cloud/aws: attempting to verify the autoscaling group "+
 		"scaling operation for worker pool %v has completed successfully",
@@ -231,7 +239,7 @@ func verifyAsgUpdate(workerPool string, capacity int64,
 	for {
 		select {
 
-		case <-timeout:
+		case <-timeout.C:
 			return fmt.Errorf("timeout reached while attempting to verify the "+
 				"autoscaling group scaling operation for worker pool %v completed "+
 				"successfully", workerPool)

--- a/cloud/aws/aws_ec2_util.go
+++ b/cloud/aws/aws_ec2_util.go
@@ -61,14 +61,17 @@ func terminateInstance(instanceID, region string) error {
 
 	// Setup our timeout and ticker value.
 	ticker := time.NewTicker(time.Second * time.Duration(10))
-	timeOut := time.Tick(time.Minute * 3)
+	defer ticker.Stop()
+
+	timeOut := time.NewTicker(time.Minute * 3)
+	defer timeOut.Stop()
 
 	logging.Info("cloud/aws: confirming successful termination of "+
 		"instance %v", instanceID)
 
 	for {
 		select {
-		case <-timeOut:
+		case <-timeOut.C:
 			return fmt.Errorf("timeout reached while attempting to confirm "+
 				"the termination of instance %v", instanceID)
 
@@ -85,6 +88,8 @@ func terminateInstance(instanceID, region string) error {
 
 			resp, err := svc.DescribeInstanceStatus(params)
 			if err != nil {
+				logging.Error("cloud/aws: failed to desribe status of instance "+
+					"%v: %v", instanceID, err)
 				return err
 			}
 

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -101,14 +101,17 @@ func FindNodeByAddress(nodeRegistry *structs.NodeRegistry,
 	// Setup a ticker to poll the node registry for the specified worker node
 	// and retry up to a specified timeout.
 	ticker := time.NewTicker(time.Second * 10)
-	timeout := time.Tick(time.Minute * 5)
+	defer ticker.Stop()
+
+	timeout := time.NewTicker(time.Minute * 5)
+	defer timeout.Stop()
 
 	logging.Info("core/helper: searching for a registered node with address "+
 		"%v in worker pool %v", nodeAddress, workerPoolName)
 
 	for {
 		select {
-		case <-timeout:
+		case <-timeout.C:
 			logging.Error("core/helper: timeout reached while searching the "+
 				"node registry for a node with address %v registered in worker "+
 				"pool %v", nodeAddress, workerPoolName)
@@ -157,7 +160,10 @@ func FindNodeByRegistrationTime(nodeRegistry *structs.NodeRegistry,
 	// Setup a ticker to poll the health status of the specified worker node
 	// and retry up to a specified timeout.
 	ticker := time.NewTicker(time.Second * 10)
-	timeout := time.Tick(time.Minute * 5)
+	defer ticker.Stop()
+
+	timeout := time.NewTicker(time.Minute * 5)
+	defer timeout.Stop()
 
 	logging.Info("core/helper: determining most recently launched " +
 		"worker node")
@@ -165,7 +171,7 @@ func FindNodeByRegistrationTime(nodeRegistry *structs.NodeRegistry,
 	for {
 		select {
 
-		case <-timeout:
+		case <-timeout.C:
 			err = fmt.Errorf("core/cluster_scaling: timeout reached while "+
 				"attempting to determine the most recently launched node in worker "+
 				"pool %v", workerPoolName)


### PR DESCRIPTION
Ref: https://golang.org/pkg/time/#Tick

Apparently, `.Tick()` "leaks", `.NewTicker()` should be used instead. This could answer the weird state that I'm seeing replicator experience where it will immediately timeout when attempting to `getMostRecentInstance`, it attemps and timeouts all in the same timestamp:

![screen shot 2018-03-28 at 11 22 13 am](https://user-images.githubusercontent.com/4636740/38061556-87b2ea92-32a4-11e8-8e28-7020a0531462.png)
