### PR TITLE
Only bind RPC to localhost interface on static port for now.

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"fmt"
-	"net"
 	"os"
 	"os/signal"
 	"strings"
@@ -162,7 +161,6 @@ func (c *Command) parseFlags() *structs.Config {
 	flags.BoolVar(&cliConfig.ClusterScalingDisable, "cluster-scaling-disable", false, "")
 	flags.BoolVar(&cliConfig.JobScalingDisable, "job-scaling-disable", false, "")
 	flags.StringVar(&cliConfig.HTTPPort, "http-port", "", "")
-	flags.IntVar(&cliConfig.RPCPort, "rpc-port", 0, "")
 
 	// Telemetry configuration flags
 	flags.StringVar(&cliConfig.Telemetry.StatsdAddress, "statsd-address", "", "")
@@ -274,10 +272,6 @@ func (c *Command) setupNotifier(config *structs.Notification) (err error) {
 // initialzeAgent setups up a number of configuration clients which depend on
 // the merged configuration.
 func (c *Command) initialzeAgent(config *structs.Config) (err error) {
-
-	if config.BindAddress != base.DefaultBindAddr || config.RPCPort != base.DefaultRPCPort {
-		config.RPCAddr = &net.TCPAddr{IP: net.ParseIP(config.BindAddress), Port: config.RPCPort}
-	}
 
 	// Setup telemetry
 	if err = c.setupTelemetry(config.Telemetry); err != nil {

--- a/command/base/config.go
+++ b/command/base/config.go
@@ -3,7 +3,6 @@ package base
 import (
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"path/filepath"
 	"sort"
@@ -22,12 +21,6 @@ const (
 	LocalNomadAddress  = "http://localhost:4646"
 )
 
-var (
-	// DefaultRPCAddr is the default bind address and port for the Replicator RPC
-	// listener.
-	DefaultRPCAddr = &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1314}
-)
-
 // DefaultConfig returns a default configuration struct with sane defaults.
 func DefaultConfig() *structs.Config {
 
@@ -40,8 +33,6 @@ func DefaultConfig() *structs.Config {
 		ClusterScalingInterval: 10,
 		JobScalingInterval:     10,
 		HTTPPort:               DefaultHTTPPort,
-		RPCPort:                DefaultRPCPort,
-		RPCAddr:                DefaultRPCAddr,
 		ScalingConcurrency:     10,
 
 		Telemetry:    &structs.Telemetry{},
@@ -62,8 +53,6 @@ func DevConfig() *structs.Config {
 		ClusterScalingInterval: 10,
 		JobScalingInterval:     10,
 		HTTPPort:               DefaultHTTPPort,
-		RPCPort:                DefaultRPCPort,
-		RPCAddr:                DefaultRPCAddr,
 		ScalingConcurrency:     10,
 
 		Telemetry:    &structs.Telemetry{},

--- a/replicator/server.go
+++ b/replicator/server.go
@@ -12,6 +12,12 @@ import (
 	"github.com/elsevier-core-engineering/replicator/replicator/structs"
 )
 
+var (
+	// DefaultRPCAddr is the default bind address and port for the Replicator RPC
+	// listener.
+	DefaultRPCAddr = &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1314}
+)
+
 // Server is the Replicator server that is responsible for running the API and
 // all scaling tasks.
 type Server struct {
@@ -89,7 +95,7 @@ func NewServer(config *structs.Config) (*Server, error) {
 
 	// Start the RPC listeners
 	go s.listen()
-	logging.Info("core/server: the RPC server has started and is listening at %v", s.config.RPCAddr)
+	logging.Info("core/server: the RPC server has started and is listening at %v", DefaultRPCAddr)
 
 	return s, nil
 }
@@ -175,7 +181,7 @@ func (s *Server) setupRPC() error {
 	s.endpoints.Status = &Status{s}
 	s.rpcServer.Register(s.endpoints.Status)
 
-	list, err := net.ListenTCP("tcp", s.config.RPCAddr)
+	list, err := net.ListenTCP("tcp", DefaultRPCAddr)
 	if err != nil {
 		return err
 	}

--- a/replicator/structs/config.go
+++ b/replicator/structs/config.go
@@ -1,8 +1,6 @@
 package structs
 
 import (
-	"net"
-
 	"github.com/elsevier-core-engineering/replicator/notifier"
 )
 
@@ -60,12 +58,6 @@ type Config struct {
 	// Notification contains Replicators notification configuration params and
 	// initialized backends.
 	Notification *Notification `mapstructure:"notification"`
-
-	RPCAddr      *net.TCPAddr
-	RPCAdvertise *net.TCPAddr
-
-	// RPCPort is the RPC port on which Replicator will run and advertise.
-	RPCPort int `mapstructure:"rpc_port"`
 
 	// ScalingConcurrency sets the maximum number of concurrent scaling
 	// operations allowed for both job and worker pool scaling.
@@ -147,10 +139,6 @@ func (c *Config) Merge(b *Config) *Config {
 
 	if b.HTTPPort != "" {
 		config.HTTPPort = b.HTTPPort
-	}
-
-	if b.RPCPort > 0 {
-		config.RPCPort = b.RPCPort
 	}
 
 	if b.ScalingConcurrency > 0 {


### PR DESCRIPTION
RPC is unable to bind to 0.0.0.0 as it is not advertisable; and as
the RPC interface is only currently used by the local Replicator
agent we can leave this static for now until other features come
in. This allows the -bind-address to be 0.0.0.0 so Replicator run
can properly on Nomad.