### PR TITLE
Defer wg.Done

### DIFF
--- a/replicator/job_scaling.go
+++ b/replicator/job_scaling.go
@@ -66,93 +66,95 @@ func (s *Server) asyncJobScaling(jobScalingPolicies *structs.JobScalingPolicies)
 func (s *Server) jobScaling(id int, jobs <-chan string,
 	jobScalingPolicies *structs.JobScalingPolicies, wg *sync.WaitGroup) {
 
-	defer wg.Done()
 	// Setup references to clients for Nomad and Consul.
 	nomadClient := s.config.NomadClient
 	consulClient := s.config.ConsulClient
 
 	for jobName := range jobs {
-		logging.Debug("core/job_scaling: scaling thread %v evaluating scaling "+
-			"for job %v", id, jobName)
+		func() {
+			defer wg.Done()
+			logging.Debug("core/job_scaling: scaling thread %v evaluating scaling "+
+				"for job %v", id, jobName)
 
-		g := jobScalingPolicies.Policies[jobName]
+			g := jobScalingPolicies.Policies[jobName]
 
-		// EvaluateJobScaling performs read/write to our map therefore we wrap it
-		// in a read/write lock and remove this as soon as possible as the
-		// remaining functions only need a read lock.
-		jobScalingPolicies.Lock.Lock()
-		err := nomadClient.EvaluateJobScaling(jobName, g)
-		jobScalingPolicies.Lock.Unlock()
+			// EvaluateJobScaling performs read/write to our map therefore we wrap it
+			// in a read/write lock and remove this as soon as possible as the
+			// remaining functions only need a read lock.
+			jobScalingPolicies.Lock.Lock()
+			err := nomadClient.EvaluateJobScaling(jobName, g)
+			jobScalingPolicies.Lock.Unlock()
 
-		// Horrible but required for jobs that have been purged as the policy
-		// watcher will not get notified and as such, cannot remove the policy even
-		// though the job doesn't exist. The string check is due to
-		// github.com/hashicorp/nomad/issues/1849
-		if err != nil && strings.Contains(err.Error(), "404") {
-			client.RemoveJobScalingPolicy(jobName, jobScalingPolicies)
+			// Horrible but required for jobs that have been purged as the policy
+			// watcher will not get notified and as such, cannot remove the policy even
+			// though the job doesn't exist. The string check is due to
+			// github.com/hashicorp/nomad/issues/1849
+			if err != nil && strings.Contains(err.Error(), "404") {
+				client.RemoveJobScalingPolicy(jobName, jobScalingPolicies)
 
-			continue
-		} else if err != nil {
-			logging.Error("core/job_scaling: unable to perform job resource "+
-				"evaluation: %v", err)
+				return
+			} else if err != nil {
+				logging.Error("core/job_scaling: unable to perform job resource "+
+					"evaluation: %v", err)
 
-			continue
-		}
-
-		jobScalingPolicies.Lock.RLock()
-
-		for _, group := range g {
-			// Setup a failure message to pass to the failsafe check.
-			message := &notifier.FailureMessage{
-				AlertUID:     group.UID,
-				ResourceID:   fmt.Sprintf("%s/%s", jobName, group.GroupName),
-				ResourceType: JobType,
+				return
 			}
 
-			// Read our JobGroup state and check failsafe.
-			state := &structs.ScalingState{
-				ResourceName: group.GroupName,
-				ResourceType: JobType,
-				StatePath: s.config.ConsulKeyRoot + "/state/jobs/" + jobName +
-					"/" + group.GroupName,
-			}
-			consulClient.ReadState(state, true)
+			jobScalingPolicies.Lock.RLock()
 
-			if !FailsafeCheck(state, s.config, group.RetryThreshold, message) {
-				logging.Error("core/job_scaling: job \"%v\" and group \"%v\" is in "+
-					"failsafe mode", jobName, group.GroupName)
-				continue
-			}
-
-			// Check the JobGroup scaling cooldown.
-			cd := time.Duration(group.Cooldown) * time.Second
-
-			if !state.LastScalingEvent.Before(time.Now().Add(-cd)) {
-				logging.Debug("core/job_scaling: job \"%v\" and group \"%v\" has not reached scaling cooldown threshold of %s",
-					jobName, group.GroupName, cd)
-				continue
-			}
-
-			if group.ScaleDirection == client.ScalingDirectionOut || group.ScaleDirection == client.ScalingDirectionIn {
-				if group.Enabled {
-					logging.Debug("core/job_scaling: scaling for job \"%v\" and group \"%v\" is enabled; a "+
-						"scaling operation (%v) will be requested", jobName, group.GroupName, group.ScaleDirection)
-
-					// Submit the job and group for scaling.
-					nomadClient.JobGroupScale(jobName, group, state)
-
-				} else {
-					logging.Debug("core/job_scaling: job scaling has been disabled; a "+
-						"scaling operation (%v) would have been requested for \"%v\" "+
-						"and group \"%v\"", group.ScaleDirection, jobName, group.GroupName)
+			for _, group := range g {
+				// Setup a failure message to pass to the failsafe check.
+				message := &notifier.FailureMessage{
+					AlertUID:     group.UID,
+					ResourceID:   fmt.Sprintf("%s/%s", jobName, group.GroupName),
+					ResourceType: JobType,
 				}
+
+				// Read our JobGroup state and check failsafe.
+				state := &structs.ScalingState{
+					ResourceName: group.GroupName,
+					ResourceType: JobType,
+					StatePath: s.config.ConsulKeyRoot + "/state/jobs/" + jobName +
+						"/" + group.GroupName,
+				}
+				consulClient.ReadState(state, true)
+
+				if !FailsafeCheck(state, s.config, group.RetryThreshold, message) {
+					logging.Error("core/job_scaling: job \"%v\" and group \"%v\" is in "+
+						"failsafe mode", jobName, group.GroupName)
+					continue
+				}
+
+				// Check the JobGroup scaling cooldown.
+				cd := time.Duration(group.Cooldown) * time.Second
+
+				if !state.LastScalingEvent.Before(time.Now().Add(-cd)) {
+					logging.Debug("core/job_scaling: job \"%v\" and group \"%v\" has not reached scaling cooldown threshold of %s",
+						jobName, group.GroupName, cd)
+					continue
+				}
+
+				if group.ScaleDirection == client.ScalingDirectionOut || group.ScaleDirection == client.ScalingDirectionIn {
+					if group.Enabled {
+						logging.Debug("core/job_scaling: scaling for job \"%v\" and group \"%v\" is enabled; a "+
+							"scaling operation (%v) will be requested", jobName, group.GroupName, group.ScaleDirection)
+
+						// Submit the job and group for scaling.
+						nomadClient.JobGroupScale(jobName, group, state)
+
+					} else {
+						logging.Debug("core/job_scaling: job scaling has been disabled; a "+
+							"scaling operation (%v) would have been requested for \"%v\" "+
+							"and group \"%v\"", group.ScaleDirection, jobName, group.GroupName)
+					}
+				}
+
+				// Persist our state to Consul.
+				consulClient.PersistState(state)
 			}
 
-			// Persist our state to Consul.
-			consulClient.PersistState(state)
-		}
-
-		// Release our read-only lock.
-		jobScalingPolicies.Lock.RUnlock()
+			// Release our read-only lock.
+			jobScalingPolicies.Lock.RUnlock()
+		}()
 	}
 }


### PR DESCRIPTION
Adding an anonymous func + adding `wg.Done()` above in order to guarantee that it gets called. This will prevent any edge case or future added extension that a developer may miss and prevent the `WaitGroup` from completing.

Probably easier to view these changes with the `?w=1` query parameter added to the URI.