### PR TITLE
Check if deployment exists, if not return false

### DIFF
--- a/client/job_scaling.go
+++ b/client/job_scaling.go
@@ -185,12 +185,17 @@ func (c *nomadClient) IsJobInDeployment(jobName string) (isRunning bool) {
 		return
 	}
 
-	switch resp.Status {
-	case nomadstructs.DeploymentStatusRunning:
-		return true
-	case nomadstructs.DeploymentStatusDescriptionPaused:
-		return true
-	default:
+	if resp == nil {
+		logging.Debug("client/job_scaling: no deployments found for job: %v", jobName)
 		return false
+	} else {
+		switch resp.Status {
+		case nomadstructs.DeploymentStatusRunning:
+			return true
+		case nomadstructs.DeploymentStatusDescriptionPaused:
+			return true
+		default:
+			return false
+		}
 	}
 }


### PR DESCRIPTION
This fixes the first issue found when upgrading to 0.8.0, maybe more coming. This change is backwards compatible with Nomad versions < 0.8.0.
```
Apr 13 22:21:19 ip-10-2-19-141 replicator[2881]: panic: runtime error: invalid memory address or nil pointer dereference
Apr 13 22:21:19 ip-10-2-19-141 replicator[2881]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0xb13a0e]
Apr 13 22:21:19 ip-10-2-19-141 replicator[2881]: 
Apr 13 22:21:19 ip-10-2-19-141 replicator[2881]: goroutine 27 [running]:
Apr 13 22:21:19 ip-10-2-19-141 replicator[2881]: github.com/elsevier-core-engineering/replicator/client.(*nomadClient).IsJobInDeployment(0xc420166138, 0xc420023200, 0x1c, 0xa)
Apr 13 22:21:19 ip-10-2-19-141 replicator[2881]: #011/go/src/github.com/elsevier-core-engineering/replicator/client/job_scaling.go:188 +0x10e
Apr 13 22:21:19 ip-10-2-19-141 replicator[2881]: github.com/elsevier-core-engineering/replicator/replicator.(*Server).asyncJobScaling(0xc42015ca50, 0xc4201f9170)
Apr 13 22:21:19 ip-10-2-19-141 replicator[2881]: #011/go/src/github.com/elsevier-core-engineering/replicator/replicator/job_scaling.go:56 +0x29d
Apr 13 22:21:19 ip-10-2-19-141 replicator[2881]: github.com/elsevier-core-engineering/replicator/replicator.(*Server).jobScalingTicker(0xc42015ca50, 0xc4201f9170)
Apr 13 22:21:19 ip-10-2-19-141 replicator[2881]: #011/go/src/github.com/elsevier-core-engineering/replicator/replicator/server.go:138 +0x16c
Apr 13 22:21:19 ip-10-2-19-141 replicator[2881]: created by github.com/elsevier-core-engineering/replicator/replicator.NewServer
Apr 13 22:21:19 ip-10-2-19-141 replicator[2881]: #011/go/src/github.com/elsevier-core-engineering/replicator/replicator/server.go:82 +0x3fc
```