### PR TITLE
Dont trigger scale action if job is unstable

### DIFF
--- a/client/job_scaling.go
+++ b/client/job_scaling.go
@@ -56,6 +56,11 @@ func (c *nomadClient) JobGroupScale(jobName string, group *structs.GroupScalingP
 		}
 	}
 
+	// Ensure that job is stable before triggering scale action
+	if !*jobResp.Stable {
+		logging.Warning("client/job_scaling: Job %s is not stable. Bailing on scale action.", jobName)
+		return
+	}
 	// Submit the job to the Register API endpoint with the altered count number
 	// and check that no error is returned.
 	resp, _, err := c.nomad.Jobs().Register(jobResp, &nomad.WriteOptions{})

--- a/client/job_scaling.go
+++ b/client/job_scaling.go
@@ -33,10 +33,15 @@ func (c *nomadClient) JobGroupScale(jobName string, group *structs.GroupScalingP
 	// Use the current task count in order to determine whether or not a scaling
 	// event will violate the min/max job policy.
 	for i, taskGroup := range jobResp.TaskGroups {
+		if group.GroupName != *taskGroup.Name {
+			// There could be multiple groups in a job - make sure we match the group name.
+			continue
+		}
+
 		if group.ScaleDirection == ScalingDirectionOut && *taskGroup.Count >= group.Max ||
 			group.ScaleDirection == ScalingDirectionIn && *taskGroup.Count <= group.Min {
-			logging.Debug("client/job_scaling: scale %v not permitted due to constraints on job \"%v\" and group \"%v\"",
-				group.ScaleDirection, *jobResp.ID, group.GroupName)
+			logging.Debug("client/job_scaling: scale %v not permitted due to constraints on job \"%v\" and group \"%v\", targetCount: %d, GroupMin: %d GroupMax: %d",
+				group.ScaleDirection, *jobResp.ID, group.GroupName, *taskGroup.Count, group.Min, group.Max)
 			return
 		}
 

--- a/client/job_scaling_policies.go
+++ b/client/job_scaling_policies.go
@@ -132,13 +132,14 @@ func (c *nomadClient) jobScalingPolicyProcessor(jobID string, scaling *structs.J
 		if len(missedKeys) == 0 {
 			logging.Debug("client/job_scaling_policies: job %s and group %v has all meta required for autoscaling",
 				jobID, *group.Name)
-			go func() {
-				err := updateScalingPolicy(jobID, *group.Name, group.Meta, scaling)
+
+			go func(jobID, groupName string, groupMeta map[string]string, scaling *structs.JobScalingPolicies) {
+				err := updateScalingPolicy(jobID, groupName, groupMeta, scaling)
 				if err != nil {
 					logging.Error("client/job_scaling_policies: unable to update scaling policy for job %v and group %v: %v",
 						jobID, group.Name, err)
 				}
-			}()
+			}(jobID, *group.Name, group.Meta, scaling)
 		}
 	}
 }

--- a/client/nomad.go
+++ b/client/nomad.go
@@ -115,6 +115,8 @@ func (c *nomadClient) MostUtilizedGroupResource(gsp *structs.GroupScalingPolicy)
 	case gsp.Tasks.Resources.MemoryPercent:
 		gsp.ScalingMetric = ScalingMetricMemory
 	}
+	logging.Debug("Most Utilized group resource for group: %s is %v, CPU is %v, Mem is %v",
+		gsp.GroupName, gsp.ScalingMetric, gsp.Tasks.Resources.CPUPercent, gsp.Tasks.Resources.MemoryPercent)
 }
 
 // LeastAllocatedNode determines which worker pool node is consuming the least

--- a/version/version.go
+++ b/version/version.go
@@ -8,7 +8,7 @@ const Version = "1.1.0"
 // VersionPrerelease is a pre-release marker for the version. If this is ""
 // (empty string) then it means that it is a final release. Otherwise, this is
 // a pre-release such as "dev" (in development), "beta", "rc1", etc.
-const VersionPrerelease = "beta1"
+const VersionPrerelease = "beta2"
 
 // Get returns a human readable version of replicator.
 func Get() string {


### PR DESCRIPTION
We use levant to deploy jobs but when replicator decides to scale-in/out while a levant deploy is running, the levant deploy gets canceled by Nomad.

This is bad for CI setups because it cancels deployments which might contain critical bug fixes for example. This PR checks make Replicator bail out on a scale action if the job is unstable.